### PR TITLE
Feature/delete ootd gender

### DIFF
--- a/src/main/java/zip/ootd/ootdzip/ootd/data/OotdGetAllRes.java
+++ b/src/main/java/zip/ootd/ootdzip/ootd/data/OotdGetAllRes.java
@@ -13,7 +13,6 @@ import zip.ootd.ootdzip.ootdimage.domain.OotdImage;
 import zip.ootd.ootdzip.ootdimageclothe.domain.Coordinate;
 import zip.ootd.ootdzip.ootdimageclothe.domain.OotdImageClothes;
 import zip.ootd.ootdzip.ootdstyle.domain.OotdStyle;
-import zip.ootd.ootdzip.user.domain.UserGender;
 
 @Data
 public class OotdGetAllRes {
@@ -38,8 +37,6 @@ public class OotdGetAllRes {
 
     private LocalDateTime createAt;
 
-    private UserGender gender;
-
     private List<OotdImageRes> ootdImages;
 
     private List<OotdStyleRes> styles;
@@ -58,7 +55,6 @@ public class OotdGetAllRes {
         this.isLike = isLike;
         this.reportCount = ootd.getReportCount();
         this.contents = ootd.getContents();
-        this.gender = ootd.getGender();
         this.createAt = ootd.getCreatedAt();
 
         this.name = ootd.getWriter().getName();

--- a/src/main/java/zip/ootd/ootdzip/ootd/data/OotdGetRes.java
+++ b/src/main/java/zip/ootd/ootdzip/ootd/data/OotdGetRes.java
@@ -13,7 +13,6 @@ import zip.ootd.ootdzip.ootdimage.domain.OotdImage;
 import zip.ootd.ootdzip.ootdimageclothe.domain.Coordinate;
 import zip.ootd.ootdzip.ootdimageclothe.domain.OotdImageClothes;
 import zip.ootd.ootdzip.ootdstyle.domain.OotdStyle;
-import zip.ootd.ootdzip.user.domain.UserGender;
 
 @Data
 public class OotdGetRes {
@@ -32,8 +31,6 @@ public class OotdGetRes {
 
     private LocalDateTime createAt;
 
-    private UserGender gender;
-
     private List<OotdImageRes> ootdImages;
 
     private List<OotdStyleRes> styles;
@@ -51,7 +48,6 @@ public class OotdGetRes {
 
         this.reportCount = ootd.getReportCount();
         this.contents = ootd.getContents();
-        this.gender = ootd.getGender();
         this.createAt = ootd.getCreatedAt();
 
         this.styles = ootd.getStyles().stream()

--- a/src/main/java/zip/ootd/ootdzip/ootd/data/OotdPostReq.java
+++ b/src/main/java/zip/ootd/ootdzip/ootd/data/OotdPostReq.java
@@ -4,7 +4,6 @@ import java.util.List;
 
 import jakarta.validation.constraints.NotEmpty;
 import lombok.Data;
-import zip.ootd.ootdzip.user.domain.UserGender;
 
 @Data
 public class OotdPostReq {
@@ -12,8 +11,6 @@ public class OotdPostReq {
     private String content;
 
     private Boolean isPrivate;
-
-    private UserGender gender;
 
     private List<Long> styles;
 

--- a/src/main/java/zip/ootd/ootdzip/ootd/domain/Ootd.java
+++ b/src/main/java/zip/ootd/ootdzip/ootd/domain/Ootd.java
@@ -9,8 +9,6 @@ import java.util.Optional;
 import jakarta.persistence.CascadeType;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
-import jakarta.persistence.EnumType;
-import jakarta.persistence.Enumerated;
 import jakarta.persistence.FetchType;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
@@ -27,7 +25,6 @@ import zip.ootd.ootdzip.ootdimage.domain.OotdImage;
 import zip.ootd.ootdzip.ootdlike.domain.OotdLike;
 import zip.ootd.ootdzip.ootdstyle.domain.OotdStyle;
 import zip.ootd.ootdzip.user.domain.User;
-import zip.ootd.ootdzip.user.domain.UserGender;
 
 @Entity
 @Table(name = "ootds")
@@ -83,20 +80,14 @@ public class Ootd extends BaseEntity {
     @Column(nullable = false)
     private boolean isPrivate;
 
-    @Column(nullable = false)
-    @Enumerated(EnumType.STRING)
-    private UserGender gender;
-
     public static Ootd createOotd(User user,
             String contents,
-            UserGender gender,
             boolean isPrivate,
             List<OotdImage> ootdImages,
             List<OotdStyle> ootdStyles) {
 
         Ootd ootd = Ootd.builder()
                 .writer(user)
-                .gender(gender)
                 .isPrivate(isPrivate)
                 .contents(contents)
                 .build();

--- a/src/main/java/zip/ootd/ootdzip/ootd/service/OotdService.java
+++ b/src/main/java/zip/ootd/ootdzip/ootd/service/OotdService.java
@@ -59,7 +59,6 @@ public class OotdService {
 
         Ootd ootd = Ootd.createOotd(userService.getAuthenticatiedUser(),
                 request.getContent(),
-                request.getGender(),
                 request.getIsPrivate(),
                 ootdImages,
                 ootdStyles);


### PR DESCRIPTION
## 변경 내용
1. OOTD 게시글에 성별이 필요없다하여 entity 에서 성별을 삭제해 service, dto 도 수정되었습니다.


## 참고 사항
OOTD Entity 에서 성별을 남겨두고 등록유저 성별을 저장할지 고민했지만, OOTD 에서는 작성자 엔티티를 가지고있으므로 그럴 필요 없다고 판단했습니다.

close #70 