### PR TITLE
Feature/update ootd

### DIFF
--- a/src/main/java/zip/ootd/ootdzip/ootd/controller/OotdController.java
+++ b/src/main/java/zip/ootd/ootdzip/ootd/controller/OotdController.java
@@ -42,7 +42,7 @@ public class OotdController {
         return new ApiResponse<>(response);
     }
 
-    @Operation(summary = "ootd 게시글, 공개/비공개 여부 수정", description = "ootd 글과 공개여부만 수정하는 api, !사진, 옷, 스타일 수정은 전체 수정 api 를 사용해 주세요!")
+    @Operation(summary = "ootd 내용, 공개/비공개 여부 수정", description = "ootd 글과 공개여부만 수정하는 api")
     @PatchMapping("/{id}")
     public ApiResponse<Boolean> updateOotdContentsAndIsPrivate(@PathVariable Long id,
             @RequestBody OotdPatchReq request) {

--- a/src/main/java/zip/ootd/ootdzip/ootd/controller/OotdController.java
+++ b/src/main/java/zip/ootd/ootdzip/ootd/controller/OotdController.java
@@ -4,8 +4,10 @@ import java.util.List;
 
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
@@ -17,8 +19,10 @@ import lombok.RequiredArgsConstructor;
 import zip.ootd.ootdzip.common.response.ApiResponse;
 import zip.ootd.ootdzip.ootd.data.OotdGetAllRes;
 import zip.ootd.ootdzip.ootd.data.OotdGetRes;
+import zip.ootd.ootdzip.ootd.data.OotdPatchReq;
 import zip.ootd.ootdzip.ootd.data.OotdPostReq;
 import zip.ootd.ootdzip.ootd.data.OotdPostRes;
+import zip.ootd.ootdzip.ootd.data.OotdPutReq;
 import zip.ootd.ootdzip.ootd.service.OotdService;
 
 @RestController
@@ -36,6 +40,26 @@ public class OotdController {
         OotdPostRes response = new OotdPostRes(ootdService.postOotd(request));
 
         return new ApiResponse<>(response);
+    }
+
+    @Operation(summary = "ootd 게시글, 공개/비공개 여부 수정", description = "ootd 글과 공개여부만 수정하는 api, !사진, 옷, 스타일 수정은 전체 수정 api 를 사용해 주세요!")
+    @PatchMapping("/{id}")
+    public ApiResponse<Boolean> updateOotdContentsAndIsPrivate(@PathVariable Long id,
+            @RequestBody OotdPatchReq request) {
+
+        ootdService.updateContentsAndIsPrivate(id, request);
+
+        return new ApiResponse<>(true);
+    }
+
+    @Operation(summary = "ootd 전체 수정", description = "ootd 게시글 전체 수정 api")
+    @PutMapping("/{id}")
+    public ApiResponse<Boolean> updateOotdAll(@PathVariable Long id,
+            @RequestBody @Valid OotdPutReq request) {
+
+        ootdService.updateAll(id, request);
+
+        return new ApiResponse<>(true);
     }
 
     @Operation(summary = "ootd 조회", description = "ootd id 를 주면 해당 id에 해당하는 ootd 반환 api")

--- a/src/main/java/zip/ootd/ootdzip/ootd/data/OotdGetRes.java
+++ b/src/main/java/zip/ootd/ootdzip/ootd/data/OotdGetRes.java
@@ -11,6 +11,7 @@ import zip.ootd.ootdzip.clothes.domain.Clothes;
 import zip.ootd.ootdzip.ootd.domain.Ootd;
 import zip.ootd.ootdzip.ootdimage.domain.OotdImage;
 import zip.ootd.ootdzip.ootdimageclothe.domain.Coordinate;
+import zip.ootd.ootdzip.ootdimageclothe.domain.DeviceSize;
 import zip.ootd.ootdzip.ootdimageclothe.domain.OotdImageClothes;
 import zip.ootd.ootdzip.ootdstyle.domain.OotdStyle;
 
@@ -102,8 +103,11 @@ public class OotdGetRes {
 
             private Coordinate coordinate;
 
+            private DeviceSize deviceSize;
+
             public OotdImageClothesRes(OotdImageClothes ootdImageClothes) {
                 this.coordinate = ootdImageClothes.getCoordinate();
+                this.deviceSize = ootdImageClothes.getDeviceSize();
 
                 Clothes clothes = ootdImageClothes.getClothes();
                 this.brand = new BrandRes(clothes.getBrand());

--- a/src/main/java/zip/ootd/ootdzip/ootd/data/OotdPatchReq.java
+++ b/src/main/java/zip/ootd/ootdzip/ootd/data/OotdPatchReq.java
@@ -1,0 +1,11 @@
+package zip.ootd.ootdzip.ootd.data;
+
+import lombok.Data;
+
+@Data
+public class OotdPatchReq {
+
+    private String content;
+
+    private Boolean isPrivate;
+}

--- a/src/main/java/zip/ootd/ootdzip/ootd/data/OotdPostReq.java
+++ b/src/main/java/zip/ootd/ootdzip/ootd/data/OotdPostReq.java
@@ -3,6 +3,7 @@ package zip.ootd.ootdzip.ootd.data;
 import java.util.List;
 
 import jakarta.validation.constraints.NotEmpty;
+import jakarta.validation.constraints.Size;
 import lombok.Data;
 
 @Data
@@ -14,12 +15,13 @@ public class OotdPostReq {
 
     private List<Long> styles;
 
+    @Size(min = 1, message = "OOTD 게시글에는 반드시 1장 이상의 이미지가 있어야 합니다.")
     private List<OotdImageReq> ootdImages;
 
     @Data
     public static class OotdImageReq {
 
-        @NotEmpty(message = "이미지는 반드시 1장 이상이여야 합니다.")
+        @NotEmpty(message = "OOTD 이미지는 반드시 존재해야 합니다.")
         private String ootdImage;
 
         private List<ClothesTagReq> clothesTags;

--- a/src/main/java/zip/ootd/ootdzip/ootd/data/OotdPutReq.java
+++ b/src/main/java/zip/ootd/ootdzip/ootd/data/OotdPutReq.java
@@ -1,0 +1,43 @@
+package zip.ootd.ootdzip.ootd.data;
+
+import java.util.List;
+
+import jakarta.validation.constraints.NotEmpty;
+import jakarta.validation.constraints.Size;
+import lombok.Data;
+
+@Data
+public class OotdPutReq {
+
+    private String content;
+
+    private Boolean isPrivate;
+
+    private List<Long> styles;
+
+    @Size(min = 1, message = "OOTD 게시글에는 반드시 1장 이상의 이미지가 있어야 합니다.")
+    private List<OotdImageReq> ootdImages;
+
+    @Data
+    public static class OotdImageReq {
+
+        @NotEmpty(message = "OOTD 이미지는 반드시 존재해야 합니다.")
+        private String ootdImage;
+
+        private List<ClothesTagReq> clothesTags;
+
+        @Data
+        public static class ClothesTagReq {
+
+            private Long clothesId;
+
+            private String xRate;
+
+            private String yRate;
+
+            private Long deviceWeight;
+
+            private Long deviceHeight;
+        }
+    }
+}

--- a/src/main/java/zip/ootd/ootdzip/ootd/domain/Ootd.java
+++ b/src/main/java/zip/ootd/ootdzip/ootd/domain/Ootd.java
@@ -98,6 +98,24 @@ public class Ootd extends BaseEntity {
         return ootd;
     }
 
+    public void updateContentsAndIsPrivate(String contents, boolean isPrivate) {
+        this.contents = contents;
+        this.isPrivate = isPrivate;
+    }
+
+    public void updateAll(String contents,
+            boolean isPrivate,
+            List<OotdImage> ootdImages,
+            List<OotdStyle> ootdStyles) {
+
+        updateContentsAndIsPrivate(contents, isPrivate);
+
+        this.ootdImages.clear();
+        this.addOotdImages(ootdImages);
+        this.styles.clear();
+        this.addOotdStyles(ootdStyles);
+    }
+
     public void updateViewCount(int viewCount) {
         this.viewCount = viewCount;
     }

--- a/src/main/java/zip/ootd/ootdzip/ootd/service/OotdService.java
+++ b/src/main/java/zip/ootd/ootdzip/ootd/service/OotdService.java
@@ -76,7 +76,7 @@ public class OotdService {
         ootd.updateContentsAndIsPrivate(request.getContent(), request.getIsPrivate());
     }
 
-    public void updateAll(Long id, OotdPutReq request){
+    public void updateAll(Long id, OotdPutReq request) {
 
         Ootd ootd = ootdRepository.findById(id).orElseThrow();
 


### PR DESCRIPTION
## 변경 내용
1. Ootd 를 수정할 수 있는 로직이 추가되었습니다. 게시글, 공개여부만 수정하는 api 와 전체수정 api 가 있습니다. 단순히 게시글, 공개여부만 수정하는데 많은 비용을 쓰는 전체 수정 api 를 사용하는것은 과하다고 판단되어 나눴습니다. 
2. Ootd 등록 DTO 에 이미지 1장이상시 등록되도록 검사조건을 추가했습니다.
3. Ootd 조회 DTO 에 누락된 필드가 있어 추가했습니다.

close #14 