### PR TITLE
Feature/delete ootd

### DIFF
--- a/src/main/java/zip/ootd/ootdzip/ootd/controller/OotdController.java
+++ b/src/main/java/zip/ootd/ootdzip/ootd/controller/OotdController.java
@@ -62,6 +62,15 @@ public class OotdController {
         return new ApiResponse<>(true);
     }
 
+    @Operation(summary = "ootd 삭제", description = "ootd 게시글 삭제하는 api 입니다.")
+    @DeleteMapping("/{id}")
+    public ApiResponse<Boolean> deleteOotd(@PathVariable Long id) {
+
+        ootdService.deleteOotd(id);
+
+        return new ApiResponse<>(true);
+    }
+
     @Operation(summary = "ootd 조회", description = "ootd id 를 주면 해당 id에 해당하는 ootd 반환 api")
     @GetMapping("/{id}")
     public ApiResponse<OotdGetRes> getOotdPost(@PathVariable Long id) {

--- a/src/main/java/zip/ootd/ootdzip/ootd/domain/Ootd.java
+++ b/src/main/java/zip/ootd/ootdzip/ootd/domain/Ootd.java
@@ -62,11 +62,11 @@ public class Ootd extends BaseEntity {
     private Integer likeCount = 0;
 
     @Builder.Default
-    @OneToMany(mappedBy = "ootd", cascade = CascadeType.ALL)
+    @OneToMany(mappedBy = "ootd", cascade = CascadeType.ALL, orphanRemoval = true)
     private List<OotdImage> ootdImages = new ArrayList<>();
 
     @Builder.Default
-    @OneToMany(mappedBy = "ootd", cascade = CascadeType.ALL)
+    @OneToMany(mappedBy = "ootd", cascade = CascadeType.ALL, orphanRemoval = true)
     private List<OotdStyle> styles = new ArrayList<>();
 
     @Builder.Default

--- a/src/main/java/zip/ootd/ootdzip/ootd/service/OotdService.java
+++ b/src/main/java/zip/ootd/ootdzip/ootd/service/OotdService.java
@@ -101,6 +101,10 @@ public class OotdService {
                 ootdStyles);
     }
 
+    public void deleteOotd(Long id) {
+        ootdRepository.deleteById(id);
+    }
+
     /**
      * 기본적인 단건조회 API 입니다.
      * 비공개글은 본인글이 아니면 볼 수 없습니다.


### PR DESCRIPTION
## 변경 내용
ootd 게시글 삭제기능 입니다. 

## 참고 사항
ootd 엔티티에 대해, OotdImage, OotdStyle, OotdBookmark, OotdLike 는 다른 엔티티와의 연결을 위한 중간엔티티입니다. 다대다 관계에서 추가 변경사항에 유연하게 대처하게 만들어진 중간엔티티인데 해당 중간엔티티는 ootd 에서 Cascade.ALL 로 설정되어있습니다. 여기서 주의점으로 다대다 관계에서 양측에서 Cascade.ALL 로 설정시 지워지지 않습니다. 자세한 내용은 아래글을 참조해주세요.

[https://velog.io/@woodyn1002/삽질-로그-Hibernate에서-부모가-둘인-Entity의-한쪽-부모를-지우면-참조-무결성-오류가-발생하는-문제](https://velog.io/@woodyn1002/%EC%82%BD%EC%A7%88-%EB%A1%9C%EA%B7%B8-Hibernate%EC%97%90%EC%84%9C-%EB%B6%80%EB%AA%A8%EA%B0%80-%EB%91%98%EC%9D%B8-Entity%EC%9D%98-%ED%95%9C%EC%AA%BD-%EB%B6%80%EB%AA%A8%EB%A5%BC-%EC%A7%80%EC%9A%B0%EB%A9%B4-%EC%B0%B8%EC%A1%B0-%EB%AC%B4%EA%B2%B0%EC%84%B1-%EC%98%A4%EB%A5%98%EA%B0%80-%EB%B0%9C%EC%83%9D%ED%95%98%EB%8A%94-%EB%AC%B8%EC%A0%9C)

결론을 요약하자면,
Ootd-OotdImage-OotdImageClothes-Clothes : 이기에 Clothes 에서 OotdImageClothes 를 가질시 Cascade.Persist 를 사용하면 안됩니다.
Ootd-OotdStyle-Style : 이기에 Style 에서 OotdStyle 를 가질시 Cascade.Persist 를 사용하면 안됩니다.
 

close #15 