### PR TITLE
Feature/update ootd comment

### DIFF
--- a/src/main/java/zip/ootd/ootdzip/comment/controller/CommentController.java
+++ b/src/main/java/zip/ootd/ootdzip/comment/controller/CommentController.java
@@ -1,0 +1,32 @@
+package zip.ootd.ootdzip.comment.controller;
+
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import zip.ootd.ootdzip.comment.data.CommentPostReq;
+import zip.ootd.ootdzip.comment.service.CommentService;
+import zip.ootd.ootdzip.common.response.ApiResponse;
+
+@RestController
+@RequiredArgsConstructor
+@Tag(name = "Comment 컨트롤러", description = "comment 관련 api")
+@RequestMapping("/api/v1/comment")
+public class CommentController {
+
+    private final CommentService commentService;
+
+    @Operation(summary = "comment 작성", description = "사용자가 작성한 comment 를 저장하는 api")
+    @PostMapping("/")
+    public ApiResponse<Boolean> saveComment(@RequestBody @Valid CommentPostReq request) {
+
+        commentService.saveComment(request);
+
+        return new ApiResponse<>(true);
+    }
+}

--- a/src/main/java/zip/ootd/ootdzip/comment/data/CommentPostReq.java
+++ b/src/main/java/zip/ootd/ootdzip/comment/data/CommentPostReq.java
@@ -1,0 +1,22 @@
+package zip.ootd.ootdzip.comment.data;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import lombok.Data;
+
+@Data
+public class CommentPostReq {
+
+    @NotNull
+    private Long ootdId;
+
+    private String taggedUserName;
+
+    private Long commentParentId;
+
+    @NotNull
+    private int parentDepth;
+
+    @NotBlank
+    private String content;
+}

--- a/src/main/java/zip/ootd/ootdzip/comment/domain/Comment.java
+++ b/src/main/java/zip/ootd/ootdzip/comment/domain/Comment.java
@@ -1,17 +1,20 @@
-package zip.ootd.ootdzip.comment;
+package zip.ootd.ootdzip.comment.domain;
 
 import java.util.ArrayList;
 import java.util.List;
 
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
 import jakarta.persistence.OneToMany;
 import jakarta.persistence.Table;
 import lombok.AllArgsConstructor;
+import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import lombok.Setter;
 import zip.ootd.ootdzip.common.entity.BaseEntity;
 import zip.ootd.ootdzip.ootd.domain.Ootd;
 import zip.ootd.ootdzip.user.domain.User;
@@ -19,26 +22,46 @@ import zip.ootd.ootdzip.user.domain.User;
 @Entity
 @Table(name = "Comments")
 @Getter
+@Setter
+@Builder
 @NoArgsConstructor
 @AllArgsConstructor
 public class Comment extends BaseEntity {
-    @ManyToOne
+
+    @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "ootd_id", nullable = false)
     private Ootd ootd;
 
-    @ManyToOne
+    @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "user_id", nullable = false)
     private User writer;
 
+    @ManyToOne(fetch = FetchType.LAZY)
+    private User taggedUser;
+
+    @Builder.Default
+    private int depth = 0;
+
+    @Builder.Default
+    private int report = 0;
+
     private String contents;
 
+    @Builder.Default
     @Column(nullable = false)
     private Boolean isDeleted = false;
 
-    @ManyToOne
-    @JoinColumn(name = "parent_id", nullable = true)
-    private Comment parent;
+    @Builder.Default
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "parent_id")
+    private Comment parent = null;
 
+    @Builder.Default
     @OneToMany(mappedBy = "parent")
-    private List<Comment> children = new ArrayList<>();
+    private List<Comment> childComments = new ArrayList<>();
+
+    public void addChildComment(Comment comment) {
+        childComments.add(comment);
+        comment.setParent(this);
+    }
 }

--- a/src/main/java/zip/ootd/ootdzip/comment/domain/Comment.java
+++ b/src/main/java/zip/ootd/ootdzip/comment/domain/Comment.java
@@ -1,5 +1,9 @@
 package zip.ootd.ootdzip.comment.domain;
 
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.LocalTime;
+import java.time.temporal.ChronoUnit;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -63,5 +67,45 @@ public class Comment extends BaseEntity {
     public void addChildComment(Comment comment) {
         childComments.add(comment);
         comment.setParent(this);
+    }
+
+    /**
+     * 1분 미만 : 지금
+     * 60분 미만 : 몇분전
+     * 24시간 미만 : 몇시간전
+     * 일주일 미만 : 몇일전
+     * 한달 미만 : 몇주전
+     * 일년 미만 : 몇개월전
+     * 일년 이상 : 몇년전
+     */
+    public String compareCreatedTimeAndNow() {
+        LocalTime createdTimeLT = this.createdAt.toLocalTime();
+        LocalTime nowLT = LocalDateTime.now().toLocalTime();
+
+        LocalDate createdTimeLD = this.createdAt.toLocalDate();
+        LocalDate nowLD = LocalDateTime.now().toLocalDate();
+
+        long seconds = ChronoUnit.SECONDS.between(createdTimeLT, nowLT);
+        if (seconds < 60) {
+            return "지금";
+        } else if (seconds < 3600) { // 3600 = 1시간
+            long minutes = ChronoUnit.MINUTES.between(createdTimeLT, nowLT);
+            return minutes + "분전";
+        } else if (seconds < 86400) { //86400 = 1일
+            long hours = ChronoUnit.HOURS.between(createdTimeLT, nowLT);
+            return hours + "시간전";
+        } else if (seconds < 604800) { //604800 = 1주일
+            long days = ChronoUnit.DAYS.between(createdTimeLD, nowLD);
+            return days + "일전";
+        } else if (seconds < 2419200) { //2419200 = 1달
+            long weeks = ChronoUnit.WEEKS.between(createdTimeLD, nowLD);
+            return weeks + "주전";
+        } else if (seconds < 29030400) { // 29030400 = 1년
+            long months = ChronoUnit.MONTHS.between(createdTimeLD, nowLD);
+            return months + "달전";
+        } else {
+            long years = ChronoUnit.YEARS.between(createdTimeLD, nowLD);
+            return years + "년전";
+        }
     }
 }

--- a/src/main/java/zip/ootd/ootdzip/comment/domain/Comment.java
+++ b/src/main/java/zip/ootd/ootdzip/comment/domain/Comment.java
@@ -20,7 +20,7 @@ import zip.ootd.ootdzip.ootd.domain.Ootd;
 import zip.ootd.ootdzip.user.domain.User;
 
 @Entity
-@Table(name = "Comments")
+@Table(name = "comments")
 @Getter
 @Setter
 @Builder

--- a/src/main/java/zip/ootd/ootdzip/comment/repository/CommentRepository.java
+++ b/src/main/java/zip/ootd/ootdzip/comment/repository/CommentRepository.java
@@ -1,0 +1,10 @@
+package zip.ootd.ootdzip.comment.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import zip.ootd.ootdzip.comment.domain.Comment;
+
+public interface CommentRepository extends JpaRepository<Comment, Long> {
+
+}
+

--- a/src/main/java/zip/ootd/ootdzip/comment/service/CommentService.java
+++ b/src/main/java/zip/ootd/ootdzip/comment/service/CommentService.java
@@ -1,0 +1,61 @@
+package zip.ootd.ootdzip.comment.service;
+
+import org.springframework.stereotype.Service;
+
+import jakarta.transaction.Transactional;
+import lombok.RequiredArgsConstructor;
+import zip.ootd.ootdzip.comment.data.CommentPostReq;
+import zip.ootd.ootdzip.comment.domain.Comment;
+import zip.ootd.ootdzip.comment.repository.CommentRepository;
+import zip.ootd.ootdzip.ootd.domain.Ootd;
+import zip.ootd.ootdzip.ootd.repository.OotdRepository;
+import zip.ootd.ootdzip.user.domain.User;
+import zip.ootd.ootdzip.user.repository.UserRepository;
+import zip.ootd.ootdzip.user.service.UserService;
+
+@Service
+@Transactional
+@RequiredArgsConstructor
+public class CommentService {
+
+    private final CommentRepository commentRepository;
+    private final UserService userService;
+    private final UserRepository userRepository;
+    private final OotdRepository ootdRepository;
+
+    /**
+     * 댓글 기능
+     * 댓글, 대댓글까지 허용(대대댓글 불가능)
+     * 대댓글을 반드시 누구에 대한 대댓글인지 태깅이 명시되어야함
+     * Depth 의 경우 댓글이 1, 대댓글이 2
+     */
+    public void saveComment(CommentPostReq request) {
+
+        User writer = userService.getAuthenticatiedUser();
+        Ootd ootd = ootdRepository.findById(request.getOotdId()).orElseThrow();
+        Comment comment;
+
+        int parentDepth = request.getParentDepth();
+        if (parentDepth == 0) {
+            comment = Comment.builder()
+                    .ootd(ootd)
+                    .writer(writer)
+                    .depth(parentDepth + 1)
+                    .contents(request.getContent())
+                    .build();
+        } else {
+            User taggedUser = userRepository.findByName(request.getTaggedUserName()).orElseThrow();
+            Comment parentComment = commentRepository.findById(request.getCommentParentId()).orElseThrow();
+            comment = Comment.builder()
+                    .ootd(ootd)
+                    .writer(writer)
+                    .depth(parentDepth + 1)
+                    .contents(request.getContent())
+                    .taggedUser(taggedUser)
+                    .build();
+            parentComment.addChildComment(comment);
+        }
+
+        commentRepository.save(comment);
+    }
+}

--- a/src/main/java/zip/ootd/ootdzip/comment/service/CommentService.java
+++ b/src/main/java/zip/ootd/ootdzip/comment/service/CommentService.java
@@ -43,6 +43,7 @@ public class CommentService {
                     .depth(parentDepth + 1)
                     .contents(request.getContent())
                     .build();
+            ootd.addComment(comment); // 대댓글이 아닌 댓글만 ootd 에 저장
         } else {
             User taggedUser = userRepository.findByName(request.getTaggedUserName()).orElseThrow();
             Comment parentComment = commentRepository.findById(request.getCommentParentId()).orElseThrow();

--- a/src/main/java/zip/ootd/ootdzip/ootd/data/OotdGetRes.java
+++ b/src/main/java/zip/ootd/ootdzip/ootd/data/OotdGetRes.java
@@ -8,6 +8,7 @@ import lombok.Data;
 import zip.ootd.ootdzip.brand.domain.Brand;
 import zip.ootd.ootdzip.category.domain.Category;
 import zip.ootd.ootdzip.clothes.domain.Clothes;
+import zip.ootd.ootdzip.comment.domain.Comment;
 import zip.ootd.ootdzip.ootd.domain.Ootd;
 import zip.ootd.ootdzip.ootdimage.domain.OotdImage;
 import zip.ootd.ootdzip.ootdimageclothe.domain.Coordinate;
@@ -17,6 +18,8 @@ import zip.ootd.ootdzip.ootdstyle.domain.OotdStyle;
 
 @Data
 public class OotdGetRes {
+
+    private Long id;
 
     private String contents;
 
@@ -30,11 +33,17 @@ public class OotdGetRes {
 
     private boolean isBookmark;
 
+    private String userName;
+
+    private String userImage;
+
     private LocalDateTime createAt;
 
     private List<OotdImageRes> ootdImages;
 
     private List<OotdStyleRes> styles;
+
+    private List<OotdComment> comment;
 
     public OotdGetRes(Ootd ootd,
             boolean isLike,
@@ -47,6 +56,9 @@ public class OotdGetRes {
         this.likeCount = likeCount;
         this.isBookmark = isBookmark;
 
+        this.id = ootd.getId();
+        this.userName = ootd.getWriter().getName();
+        this.userImage = ootd.getWriter().getProfileImage();
         this.reportCount = ootd.getReportCount();
         this.contents = ootd.getContents();
         this.createAt = ootd.getCreatedAt();
@@ -57,6 +69,10 @@ public class OotdGetRes {
 
         this.ootdImages = ootd.getOotdImages().stream()
                 .map(OotdImageRes::new)
+                .collect(Collectors.toList());
+
+        this.comment = ootd.getComments().stream()
+                .map(OotdComment::new)
                 .collect(Collectors.toList());
     }
 
@@ -127,6 +143,58 @@ public class OotdGetRes {
                 public BrandRes(Brand brand) {
                     this.name = brand.getName();
                 }
+            }
+        }
+    }
+
+    @Data
+    static class OotdComment {
+
+        private Long id;
+
+        private String userName;
+
+        private String userImage;
+
+        private String content;
+
+        private LocalDateTime creatAt;
+
+        List<ChildComment> childComment;
+
+        public OotdComment(Comment comment) {
+            this.id = comment.getId();
+            this.userName = comment.getWriter().getName();
+            this.content = comment.getContents();
+            this.userImage = comment.getWriter().getProfileImage();
+            this.creatAt = comment.getCreatedAt();
+            this.childComment = comment.getChildComments().stream()
+                    .map(ChildComment::new)
+                    .collect(Collectors.toList());
+        }
+
+        @Data
+        static class ChildComment {
+
+            private Long id;
+
+            private String userName;
+
+            private String userImage;
+
+            private String content;
+
+            private LocalDateTime createAt;
+
+            private String taggedUserName;
+
+            public ChildComment(Comment comment) {
+                this.id = comment.getId();
+                this.userName = comment.getWriter().getName();
+                this.content = comment.getContents();
+                this.userImage = comment.getWriter().getProfileImage();
+                this.createAt = comment.getCreatedAt();
+                this.taggedUserName = comment.getTaggedUser().getName();
             }
         }
     }

--- a/src/main/java/zip/ootd/ootdzip/ootd/data/OotdGetRes.java
+++ b/src/main/java/zip/ootd/ootdzip/ootd/data/OotdGetRes.java
@@ -158,7 +158,7 @@ public class OotdGetRes {
 
         private String content;
 
-        private LocalDateTime creatAt;
+        private String timeStamp;
 
         List<ChildComment> childComment;
 
@@ -167,7 +167,7 @@ public class OotdGetRes {
             this.userName = comment.getWriter().getName();
             this.content = comment.getContents();
             this.userImage = comment.getWriter().getProfileImage();
-            this.creatAt = comment.getCreatedAt();
+            this.timeStamp = comment.compareCreatedTimeAndNow();
             this.childComment = comment.getChildComments().stream()
                     .map(ChildComment::new)
                     .collect(Collectors.toList());
@@ -184,7 +184,7 @@ public class OotdGetRes {
 
             private String content;
 
-            private LocalDateTime createAt;
+            private String timeStamp;
 
             private String taggedUserName;
 
@@ -193,7 +193,7 @@ public class OotdGetRes {
                 this.userName = comment.getWriter().getName();
                 this.content = comment.getContents();
                 this.userImage = comment.getWriter().getProfileImage();
-                this.createAt = comment.getCreatedAt();
+                this.timeStamp = comment.compareCreatedTimeAndNow();
                 this.taggedUserName = comment.getTaggedUser().getName();
             }
         }

--- a/src/main/java/zip/ootd/ootdzip/ootd/domain/Ootd.java
+++ b/src/main/java/zip/ootd/ootdzip/ootd/domain/Ootd.java
@@ -19,6 +19,7 @@ import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
+import zip.ootd.ootdzip.comment.domain.Comment;
 import zip.ootd.ootdzip.common.entity.BaseEntity;
 import zip.ootd.ootdzip.ootdbookmark.domain.OotdBookmark;
 import zip.ootd.ootdzip.ootdimage.domain.OotdImage;
@@ -76,6 +77,10 @@ public class Ootd extends BaseEntity {
     @Builder.Default
     @OneToMany(mappedBy = "ootd", cascade = CascadeType.ALL, orphanRemoval = true)
     private List<OotdBookmark> ootdBookmarks = new ArrayList<>();
+
+    @Builder.Default
+    @OneToMany(mappedBy = "ootd", cascade = CascadeType.ALL, orphanRemoval = true)
+    private List<Comment> comments = new ArrayList<>();
 
     @Column(nullable = false)
     private boolean isPrivate;
@@ -201,5 +206,10 @@ public class Ootd extends BaseEntity {
 
     public void deleteOotdBookmark(OotdBookmark ootdBookmark) {
         ootdBookmarks.remove(ootdBookmark);
+    }
+
+    public void addComment(Comment comment) {
+        comments.add(comment);
+        comment.setOotd(this);
     }
 }


### PR DESCRIPTION
## 변경 내용
- 댓글 작성 기능 추가
- ootd 게시글 단건 조회에 댓글 조회 추가

## 참고 사항
댓글은 프론트와 협의하여 다음과 같이 정의했습니다. 댓글, 대댓글 까지만 가능하며 대대댓글은 없습니다.(최대 depth 2) 대댓글 작성시 누구에 대한 대댓글인지 태깅이 필수적으로 추가됩니다. 
댓글 조회시 작성시간을 현재 시간과 비교하여 (ex : 지금, 5분전, 5시간전, 5일전, 3주전, 5달전, 5년전) 표시합니다. 해당 기능은 댓글 도메인에 넣어놨으며, 추후 중복되어 시간비교기능 사용시 공용 유틸로 빼놓을 예정입니다.

close #95 