### PR TITLE
Feature/delete comment(#102)

### DIFF
--- a/src/main/java/zip/ootd/ootdzip/comment/controller/CommentController.java
+++ b/src/main/java/zip/ootd/ootdzip/comment/controller/CommentController.java
@@ -1,5 +1,7 @@
 package zip.ootd.ootdzip.comment.controller;
 
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -26,6 +28,15 @@ public class CommentController {
     public ApiResponse<Boolean> saveComment(@RequestBody @Valid CommentPostReq request) {
 
         commentService.saveComment(request);
+
+        return new ApiResponse<>(true);
+    }
+
+    @Operation(summary = "comment 삭제", description = "사용자가 작성한 comment 를 삭제하는 api 로 soft delete 가 적용 됩니다.")
+    @DeleteMapping("/{id}")
+    public ApiResponse<Boolean> deleteComment(@PathVariable Long id) {
+
+        commentService.deleteOotd(id);
 
         return new ApiResponse<>(true);
     }

--- a/src/main/java/zip/ootd/ootdzip/comment/controller/CommentController.java
+++ b/src/main/java/zip/ootd/ootdzip/comment/controller/CommentController.java
@@ -22,7 +22,7 @@ public class CommentController {
     private final CommentService commentService;
 
     @Operation(summary = "comment 작성", description = "사용자가 작성한 comment 를 저장하는 api")
-    @PostMapping("/")
+    @PostMapping("")
     public ApiResponse<Boolean> saveComment(@RequestBody @Valid CommentPostReq request) {
 
         commentService.saveComment(request);

--- a/src/main/java/zip/ootd/ootdzip/comment/data/CommentPostReq.java
+++ b/src/main/java/zip/ootd/ootdzip/comment/data/CommentPostReq.java
@@ -14,9 +14,9 @@ public class CommentPostReq {
 
     private Long commentParentId;
 
-    @NotNull
+    @NotNull(message = "부모댓글인지 자식댓글인지 값을 알려주어야 합니다.")
     private int parentDepth;
 
-    @NotBlank
+    @NotBlank(message = "댓글 내용은 필수입니다.")
     private String content;
 }

--- a/src/main/java/zip/ootd/ootdzip/comment/domain/Comment.java
+++ b/src/main/java/zip/ootd/ootdzip/comment/domain/Comment.java
@@ -64,6 +64,8 @@ public class Comment extends BaseEntity {
     @Column(nullable = false)
     private Boolean isDeleted = false;
 
+    private LocalDateTime deletedAt;
+
     @Builder.Default
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "parent_id")
@@ -136,5 +138,10 @@ public class Comment extends BaseEntity {
         }
 
         return contents;
+    }
+
+    public void deleteComment() {
+        this.isDeleted = true;
+        this.deletedAt = LocalDateTime.now();
     }
 }

--- a/src/main/java/zip/ootd/ootdzip/comment/domain/Comment.java
+++ b/src/main/java/zip/ootd/ootdzip/comment/domain/Comment.java
@@ -7,6 +7,8 @@ import java.time.temporal.ChronoUnit;
 import java.util.ArrayList;
 import java.util.List;
 
+import org.hibernate.annotations.Where;
+
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.FetchType;
@@ -19,9 +21,6 @@ import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
-
-import org.hibernate.annotations.Where;
-
 import zip.ootd.ootdzip.common.entity.BaseEntity;
 import zip.ootd.ootdzip.ootd.domain.Ootd;
 import zip.ootd.ootdzip.user.domain.User;

--- a/src/main/java/zip/ootd/ootdzip/comment/domain/Comment.java
+++ b/src/main/java/zip/ootd/ootdzip/comment/domain/Comment.java
@@ -142,5 +142,9 @@ public class Comment extends BaseEntity {
     public void deleteComment() {
         this.isDeleted = true;
         this.deletedAt = LocalDateTime.now();
+
+        if (this.parent != null) {
+            parent.childCount--;
+        }
     }
 }

--- a/src/main/java/zip/ootd/ootdzip/comment/service/CommentService.java
+++ b/src/main/java/zip/ootd/ootdzip/comment/service/CommentService.java
@@ -7,6 +7,8 @@ import lombok.RequiredArgsConstructor;
 import zip.ootd.ootdzip.comment.data.CommentPostReq;
 import zip.ootd.ootdzip.comment.domain.Comment;
 import zip.ootd.ootdzip.comment.repository.CommentRepository;
+import zip.ootd.ootdzip.common.exception.CustomException;
+import zip.ootd.ootdzip.common.exception.code.ErrorCode;
 import zip.ootd.ootdzip.ootd.domain.Ootd;
 import zip.ootd.ootdzip.ootd.repository.OotdRepository;
 import zip.ootd.ootdzip.user.domain.User;
@@ -59,5 +61,21 @@ public class CommentService {
         }
 
         commentRepository.save(comment);
+    }
+
+    /**
+     * soft_delete 로 삭제합니다.
+     * 삭제여부와 삭제시간을 변경합니다.
+     * 이미 삭제된 댓글인 경우 예외를 반환합니다.
+     */
+    public void deleteOotd(Long id) {
+
+        Comment comment = commentRepository.findById(id).orElseThrow();
+
+        if (comment.getIsDeleted()) {
+            throw new CustomException(ErrorCode.DUPLICATE_DELETE_COMMENT);
+        }
+
+        comment.deleteComment();
     }
 }

--- a/src/main/java/zip/ootd/ootdzip/comment/service/CommentService.java
+++ b/src/main/java/zip/ootd/ootdzip/comment/service/CommentService.java
@@ -38,23 +38,24 @@ public class CommentService {
         int parentDepth = request.getParentDepth();
         if (parentDepth == 0) {
             comment = Comment.builder()
-                    .ootd(ootd)
                     .writer(writer)
                     .depth(parentDepth + 1)
                     .contents(request.getContent())
                     .build();
             ootd.addComment(comment); // 대댓글이 아닌 댓글만 ootd 에 저장
         } else {
-            User taggedUser = userRepository.findByName(request.getTaggedUserName()).orElseThrow();
+            User taggedUser = null;
+            if (request.getTaggedUserName() != null && !request.getTaggedUserName().isEmpty()) {
+                taggedUser = userRepository.findByName(request.getTaggedUserName()).orElseThrow();
+            }
             Comment parentComment = commentRepository.findById(request.getCommentParentId()).orElseThrow();
             comment = Comment.builder()
-                    .ootd(ootd)
                     .writer(writer)
                     .depth(parentDepth + 1)
                     .contents(request.getContent())
                     .taggedUser(taggedUser)
                     .build();
-            parentComment.addChildComment(comment);
+            parentComment.addChildComment(comment); // 대댓글의 경우 ootd 정보를 따로 저장하지 않아 ootd 확인시 부모댓글을 조회해서 ootd 를 확인해야함
         }
 
         commentRepository.save(comment);

--- a/src/main/java/zip/ootd/ootdzip/common/exception/code/ErrorCode.java
+++ b/src/main/java/zip/ootd/ootdzip/common/exception/code/ErrorCode.java
@@ -117,7 +117,10 @@ public enum ErrorCode {
 
     CANT_MY_REPORT(400, "R003", "작성자는 신고가 불가능합니다."),
 
-    NOT_FOUNT_COMMENT_ID(404, "CM001", "유효하지 않은 댓글 ID");
+    NOT_FOUNT_COMMENT_ID(404, "CM001", "유효하지 않은 댓글 ID"),
+
+    DUPLICATE_DELETE_COMMENT(400, "CM002", "이미 삭제된 댓글 입니다.");
+
 
     private final Integer status;
 

--- a/src/main/java/zip/ootd/ootdzip/common/exception/code/ErrorCode.java
+++ b/src/main/java/zip/ootd/ootdzip/common/exception/code/ErrorCode.java
@@ -121,7 +121,6 @@ public enum ErrorCode {
 
     DUPLICATE_DELETE_COMMENT(400, "CM002", "이미 삭제된 댓글 입니다.");
 
-
     private final Integer status;
 
     private final String divisionCode;

--- a/src/main/java/zip/ootd/ootdzip/ootd/data/OotdGetRes.java
+++ b/src/main/java/zip/ootd/ootdzip/ootd/data/OotdGetRes.java
@@ -200,7 +200,9 @@ public class OotdGetRes {
                 this.content = comment.getContents();
                 this.userImage = comment.getWriter().getProfileImage();
                 this.timeStamp = comment.compareCreatedTimeAndNow();
-                this.taggedUserName = comment.getTaggedUser().getName();
+                if (comment.getTaggedUser() != null) {
+                    this.taggedUserName = comment.getTaggedUser().getName();
+                }
             }
         }
     }


### PR DESCRIPTION
## 변경 내용
- 댓글 조회 로직 수정
- 댓글 삭제 기능 추가

## 참고 사항

댓글 엔티티에 `@Where` 를 적용하여 자동으로 삭제된 댓글과 일정 신고 수 이하만 조회되도록 수정되었습니다.

댓글 엔티티에 `childCount` 를 추가해 부모댓글이 대댓글 수를 알 수 있도록 하였습니다. 다른 방법으로도 대댓글 수를 알 수 있지만 필드를 추가한 이유는 `@Where` 로직에서 검사할 때 필요하기 때문입니다. 필드로 추가하지 않으면 내부쿼리로 count 를 사용해 확인해야하는데, 댓글을 조회할때마다 count 하는것은 너무 많은 자원을 사용한다고 판단했습니다.

댓글에는 ootd 정보가 저장되지만 대댓글에는 ootd 정보가 저장되지 않습니다. 대댓글은 부모댓글을 통해 ootd 정보를 알 수 있기 때문입니다. 이렇게 수정한이유는 대댓글에도 ootd 정보를 저장시, ootd 조회할때 DB 에서 Comment 테이블 조회시 댓글+대댓글을 가져오고, 추가로 댓글에서 대댓글을 조회하여 대댓글이 중복 조회됩니다. 그래서 대댓글은 ootd 정보를 저장하지 않도록 변경하였습니다.

댓글 삭제시 soft_delete 를 수행합니다. 삭제여부와 삭제시간을 저장합니다. 삭제시간 필드를 추가한이유는 추후에 삭제된 댓글을 몇일뒤에 삭제한다~ 라는조건이 있을경우 적용가능하도록 하기위함입니다. 

close #102  