### PR TITLE
OOTD 에서 댓글조회 API 분리 및 작성방식 수정

### DIFF
--- a/src/main/java/zip/ootd/ootdzip/comment/controller/CommentController.java
+++ b/src/main/java/zip/ootd/ootdzip/comment/controller/CommentController.java
@@ -1,6 +1,7 @@
 package zip.ootd.ootdzip.comment.controller;
 
 import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
@@ -11,16 +12,19 @@ import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
+import zip.ootd.ootdzip.comment.data.CommentGetAllReq;
+import zip.ootd.ootdzip.comment.data.CommentGetAllRes;
 import zip.ootd.ootdzip.comment.data.CommentPostReq;
 import zip.ootd.ootdzip.comment.data.CommentPostRes;
 import zip.ootd.ootdzip.comment.service.CommentService;
 import zip.ootd.ootdzip.common.response.ApiResponse;
+import zip.ootd.ootdzip.common.response.CommonSliceResponse;
 import zip.ootd.ootdzip.user.service.UserService;
 
 @RestController
 @RequiredArgsConstructor
 @Tag(name = "Comment 컨트롤러", description = "comment 관련 api")
-@RequestMapping("/api/v1/comment")
+@RequestMapping("/api/v1")
 public class CommentController {
 
     private final CommentService commentService;
@@ -28,7 +32,7 @@ public class CommentController {
     private final UserService userService;
 
     @Operation(summary = "comment 작성", description = "사용자가 작성한 comment 를 저장하는 api")
-    @PostMapping("")
+    @PostMapping("/comment")
     public ApiResponse<CommentPostRes> saveComment(@RequestBody @Valid CommentPostReq request) {
 
         CommentPostRes response = new CommentPostRes(
@@ -38,11 +42,20 @@ public class CommentController {
     }
 
     @Operation(summary = "comment 삭제", description = "사용자가 작성한 comment 를 삭제하는 api 로 soft delete 가 적용 됩니다.")
-    @DeleteMapping("/{id}")
+    @DeleteMapping("/comment/{id}")
     public ApiResponse<Boolean> deleteComment(@PathVariable Long id) {
 
         commentService.deleteOotd(id);
 
         return new ApiResponse<>(true);
+    }
+
+    @Operation(summary = "ootd 에 해당 하는 comment 전체 조회", description = "ootd 에 해당하는 댓글을 조회합니다.")
+    @GetMapping("/comments")
+    public ApiResponse<CommonSliceResponse<CommentGetAllRes>> getComments(@Valid CommentGetAllReq request) {
+
+        CommonSliceResponse<CommentGetAllRes> response = commentService.getComments(request);
+
+        return new ApiResponse<>(response);
     }
 }

--- a/src/main/java/zip/ootd/ootdzip/comment/data/CommentGetAllReq.java
+++ b/src/main/java/zip/ootd/ootdzip/comment/data/CommentGetAllReq.java
@@ -1,0 +1,12 @@
+package zip.ootd.ootdzip.comment.data;
+
+import jakarta.validation.constraints.NotNull;
+import lombok.Data;
+import zip.ootd.ootdzip.common.request.CommonPageRequest;
+
+@Data
+public class CommentGetAllReq extends CommonPageRequest {
+
+    @NotNull(message = "댓글 조회시 어떤 ootd 인지 id 를 알려주어야 합니다.")
+    public Long ootdId;
+}

--- a/src/main/java/zip/ootd/ootdzip/comment/data/CommentGetAllRes.java
+++ b/src/main/java/zip/ootd/ootdzip/comment/data/CommentGetAllRes.java
@@ -1,0 +1,48 @@
+package zip.ootd.ootdzip.comment.data;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import zip.ootd.ootdzip.comment.domain.Comment;
+
+@Builder
+@AllArgsConstructor
+@Data
+public class CommentGetAllRes {
+
+    private Long id;
+
+    private String userName;
+
+    private String userImage;
+
+    private String content;
+
+    private String timeStamp;
+
+    private String taggedUserName;
+
+    private int depth;
+
+    private Long parentId;
+
+    private Long groupId;
+
+    private Long groupOrder;
+
+    public static CommentGetAllRes of(Comment comment) {
+
+        return CommentGetAllRes.builder()
+                .id(comment.getId())
+                .userName(comment.getWriter().getName())
+                .userImage(comment.getWriter().getProfileImage())
+                .content(comment.getContents())
+                .timeStamp(comment.compareCreatedTimeAndNow())
+                .taggedUserName(comment.getTaggedUser() == null ? null : comment.getTaggedUser().getName())
+                .depth(comment.getDepth())
+                .groupId(comment.getGroupId())
+                .groupOrder(comment.getGroupOrder())
+                .parentId(comment.getParent() == null ? null : comment.getParent().getId())
+                .build();
+    }
+}

--- a/src/main/java/zip/ootd/ootdzip/comment/data/CommentGetAllRes.java
+++ b/src/main/java/zip/ootd/ootdzip/comment/data/CommentGetAllRes.java
@@ -28,8 +28,6 @@ public class CommentGetAllRes {
 
     private Long groupId;
 
-    private Long groupOrder;
-
     public static CommentGetAllRes of(Comment comment) {
 
         return CommentGetAllRes.builder()
@@ -41,7 +39,6 @@ public class CommentGetAllRes {
                 .taggedUserName(comment.getTaggedUser() == null ? null : comment.getTaggedUser().getName())
                 .depth(comment.getDepth())
                 .groupId(comment.getGroupId())
-                .groupOrder(comment.getGroupOrder())
                 .parentId(comment.getParent() == null ? null : comment.getParent().getId())
                 .build();
     }

--- a/src/main/java/zip/ootd/ootdzip/comment/domain/Comment.java
+++ b/src/main/java/zip/ootd/ootdzip/comment/domain/Comment.java
@@ -65,9 +65,6 @@ public class Comment extends BaseEntity {
 
     private String contents;
 
-    @Column(nullable = false)
-    private Long topOotdId;
-
     @Builder.Default
     @Column(nullable = false)
     private Boolean isDeleted = false;
@@ -82,6 +79,12 @@ public class Comment extends BaseEntity {
     @Builder.Default
     @OneToMany(mappedBy = "parent")
     private List<Comment> childComments = new ArrayList<>();
+
+    @Column(nullable = false)
+    private Long groupId;
+
+    @Column(nullable = false)
+    private Long groupOrder;
 
     public void addChildComment(Comment comment) {
         childComments.add(comment);

--- a/src/main/java/zip/ootd/ootdzip/comment/repository/CommentRepository.java
+++ b/src/main/java/zip/ootd/ootdzip/comment/repository/CommentRepository.java
@@ -1,10 +1,22 @@
 package zip.ootd.ootdzip.comment.repository;
 
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Slice;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
 
+import io.lettuce.core.dynamic.annotation.Param;
 import zip.ootd.ootdzip.comment.domain.Comment;
 
 public interface CommentRepository extends JpaRepository<Comment, Long> {
 
+    @Query("SELECT COALESCE(MAX(c.groupId), 0) from Comment c where c.ootd.id = :ootdId")
+    Long findByMaxGroupId(@Param("ootdId") Long ootdId);
+
+    @Query("SELECT COALESCE(MAX(c.groupOrder), 0) from Comment c where c.ootd.id = :ootdId and c.groupId = :groupId")
+    Long findByMaxGroupOrder(@Param("ootdId") Long ootdId, @Param("groupId") Long groupId);
+
+    @Query("SELECT c from Comment c where c.ootd.id = :ootdId")
+    Slice<Comment> getCommentByOotdId(@Param("ootdId") Long ootdId, Pageable pageable);
 }
 

--- a/src/main/java/zip/ootd/ootdzip/comment/repository/CommentRepository.java
+++ b/src/main/java/zip/ootd/ootdzip/comment/repository/CommentRepository.java
@@ -11,12 +11,12 @@ import zip.ootd.ootdzip.comment.domain.Comment;
 public interface CommentRepository extends JpaRepository<Comment, Long> {
 
     @Query("SELECT COALESCE(MAX(c.groupId), 0) from Comment c where c.ootd.id = :ootdId")
-    Long findByMaxGroupId(@Param("ootdId") Long ootdId);
+    Long findMaxGroupIdByOotdId(@Param("ootdId") Long ootdId);
 
     @Query("SELECT COALESCE(MAX(c.groupOrder), 0) from Comment c where c.ootd.id = :ootdId and c.groupId = :groupId")
-    Long findByMaxGroupOrder(@Param("ootdId") Long ootdId, @Param("groupId") Long groupId);
+    Long findMaxGroupIdByOotdIdAndGroupOrder(@Param("ootdId") Long ootdId, @Param("groupId") Long groupId);
 
     @Query("SELECT c from Comment c where c.ootd.id = :ootdId")
-    Slice<Comment> getCommentByOotdId(@Param("ootdId") Long ootdId, Pageable pageable);
+    Slice<Comment> findAllByOotdId(@Param("ootdId") Long ootdId, Pageable pageable);
 }
 

--- a/src/main/java/zip/ootd/ootdzip/comment/service/CommentService.java
+++ b/src/main/java/zip/ootd/ootdzip/comment/service/CommentService.java
@@ -48,7 +48,7 @@ public class CommentService {
         int parentDepth = request.getParentDepth();
 
         if (parentDepth == 0) {
-            Long maxGroupId = commentRepository.findByMaxGroupId(ootd.getId());
+            Long maxGroupId = commentRepository.findMaxGroupIdByOotdId(ootd.getId());
             comment = Comment.builder()
                     .writer(writer)
                     .depth(parentDepth + 1)
@@ -66,7 +66,7 @@ public class CommentService {
                 throw new CustomException(ErrorCode.NO_TAGGING_USER);
             }
             Comment parentComment = commentRepository.findById(request.getCommentParentId()).orElseThrow();
-            Long maxGroupOrder = commentRepository.findByMaxGroupOrder(ootd.getId(), parentComment.getGroupId());
+            Long maxGroupOrder = commentRepository.findMaxGroupIdByOotdIdAndGroupOrder(ootd.getId(), parentComment.getGroupId());
             comment = Comment.builder()
                     .writer(writer)
                     .depth(parentDepth + 1)
@@ -106,7 +106,7 @@ public class CommentService {
         );
         Pageable pageable = request.toPageableWithSort(sort);
 
-        Slice<Comment> comments = commentRepository.getCommentByOotdId(request.getOotdId(), pageable);
+        Slice<Comment> comments = commentRepository.findAllByOotdId(request.getOotdId(), pageable);
 
         List<CommentGetAllRes> commentGetAllResList = comments.stream()
                 .map(CommentGetAllRes::of)

--- a/src/main/java/zip/ootd/ootdzip/comment/service/CommentService.java
+++ b/src/main/java/zip/ootd/ootdzip/comment/service/CommentService.java
@@ -66,7 +66,8 @@ public class CommentService {
                 throw new CustomException(ErrorCode.NO_TAGGING_USER);
             }
             Comment parentComment = commentRepository.findById(request.getCommentParentId()).orElseThrow();
-            Long maxGroupOrder = commentRepository.findMaxGroupIdByOotdIdAndGroupOrder(ootd.getId(), parentComment.getGroupId());
+            Long maxGroupOrder = commentRepository.findMaxGroupIdByOotdIdAndGroupOrder(ootd.getId(),
+                    parentComment.getGroupId());
             comment = Comment.builder()
                     .writer(writer)
                     .depth(parentDepth + 1)

--- a/src/main/java/zip/ootd/ootdzip/comment/service/CommentService.java
+++ b/src/main/java/zip/ootd/ootdzip/comment/service/CommentService.java
@@ -1,14 +1,23 @@
 package zip.ootd.ootdzip.comment.service;
 
+import java.util.List;
+import java.util.stream.Collectors;
+
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Slice;
+import org.springframework.data.domain.Sort;
 import org.springframework.stereotype.Service;
 
 import jakarta.transaction.Transactional;
 import lombok.RequiredArgsConstructor;
+import zip.ootd.ootdzip.comment.data.CommentGetAllReq;
+import zip.ootd.ootdzip.comment.data.CommentGetAllRes;
 import zip.ootd.ootdzip.comment.data.CommentPostReq;
 import zip.ootd.ootdzip.comment.domain.Comment;
 import zip.ootd.ootdzip.comment.repository.CommentRepository;
 import zip.ootd.ootdzip.common.exception.CustomException;
 import zip.ootd.ootdzip.common.exception.code.ErrorCode;
+import zip.ootd.ootdzip.common.response.CommonSliceResponse;
 import zip.ootd.ootdzip.ootd.domain.Ootd;
 import zip.ootd.ootdzip.ootd.repository.OotdRepository;
 import zip.ootd.ootdzip.user.domain.User;
@@ -28,21 +37,27 @@ public class CommentService {
      * 댓글, 대댓글까지 허용(대대댓글 불가능)
      * 대댓글을 반드시 누구에 대한 대댓글인지 태깅이 명시되어야함
      * Depth 의 경우 댓글이 1, 대댓글이 2
+     * 게시물 마다 부모 댓글 기준으로 댓글 그룹 id 를 가진다.
      */
     public Comment saveComment(CommentPostReq request, User writer) {
 
         Ootd ootd = ootdRepository.findById(request.getOotdId()).orElseThrow();
+
         Comment comment;
 
         int parentDepth = request.getParentDepth();
+
         if (parentDepth == 0) {
+            Long maxGroupId = commentRepository.findByMaxGroupId(ootd.getId());
             comment = Comment.builder()
                     .writer(writer)
                     .depth(parentDepth + 1)
                     .contents(request.getContent())
-                    .topOotdId(ootd.getId())
+                    .ootd(ootd)
+                    .groupId(maxGroupId + 1L)
+                    .groupOrder(0L)
                     .build();
-            ootd.addComment(comment); // 대댓글이 아닌 댓글만 ootd 에 저장
+
         } else {
             User taggedUser;
             if (request.getTaggedUserName() != null && !request.getTaggedUserName().isEmpty()) {
@@ -51,14 +66,17 @@ public class CommentService {
                 throw new CustomException(ErrorCode.NO_TAGGING_USER);
             }
             Comment parentComment = commentRepository.findById(request.getCommentParentId()).orElseThrow();
+            Long maxGroupOrder = commentRepository.findByMaxGroupOrder(ootd.getId(), parentComment.getGroupId());
             comment = Comment.builder()
                     .writer(writer)
                     .depth(parentDepth + 1)
                     .contents(request.getContent())
                     .taggedUser(taggedUser)
-                    .topOotdId(ootd.getId())
+                    .ootd(ootd)
+                    .groupId(parentComment.getGroupId())
+                    .groupOrder(maxGroupOrder + 1L)
                     .build();
-            parentComment.addChildComment(comment); // 대댓글의 경우 ootd 정보를 따로 저장하지 않아 ootd 확인시 부모댓글을 조회해서 ootd 를 확인해야함
+            parentComment.addChildComment(comment);
         }
 
         return commentRepository.save(comment);
@@ -78,5 +96,22 @@ public class CommentService {
         }
 
         comment.deleteComment();
+    }
+
+    public CommonSliceResponse<CommentGetAllRes> getComments(CommentGetAllReq request) {
+
+        Sort sort = Sort.by(
+                Sort.Order.asc("groupId"),
+                Sort.Order.asc("groupOrder")
+        );
+        Pageable pageable = request.toPageableWithSort(sort);
+
+        Slice<Comment> comments = commentRepository.getCommentByOotdId(request.getOotdId(), pageable);
+
+        List<CommentGetAllRes> commentGetAllResList = comments.stream()
+                .map(CommentGetAllRes::of)
+                .collect(Collectors.toList());
+
+        return new CommonSliceResponse<>(commentGetAllResList, pageable, comments.isLast());
     }
 }

--- a/src/main/java/zip/ootd/ootdzip/common/request/CommonPageRequest.java
+++ b/src/main/java/zip/ootd/ootdzip/common/request/CommonPageRequest.java
@@ -2,6 +2,7 @@ package zip.ootd.ootdzip.common.request;
 
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
 import org.springframework.data.domain.Sort.Direction;
 
 import lombok.NoArgsConstructor;
@@ -26,7 +27,16 @@ public class CommonPageRequest {
         this.sortDirection = sortDirection;
     }
 
+    public CommonPageRequest(Integer page, Integer size) {
+        this.page = page;
+        this.size = size;
+    }
+
     public Pageable toPageable() {
         return PageRequest.of(this.page, this.size, sortDirection, sortCriteria);
+    }
+
+    public Pageable toPageableWithSort(Sort sort) {
+        return PageRequest.of(this.page, this.size, sort);
     }
 }

--- a/src/main/java/zip/ootd/ootdzip/common/response/CommonSliceResponse.java
+++ b/src/main/java/zip/ootd/ootdzip/common/response/CommonSliceResponse.java
@@ -17,10 +17,10 @@ public class CommonSliceResponse<T> {
 
     private boolean isLast;
 
-    public CommonSliceResponse(List<T> content, Pageable pageable, boolean hasNext) {
+    public CommonSliceResponse(List<T> content, Pageable pageable, boolean isLast) {
         this.content = content;
         this.page = pageable.getPageNumber();
         this.size = pageable.getPageSize();
-        this.isLast = hasNext;
+        this.isLast = isLast;
     }
 }

--- a/src/main/java/zip/ootd/ootdzip/ootd/data/OotdGetRes.java
+++ b/src/main/java/zip/ootd/ootdzip/ootd/data/OotdGetRes.java
@@ -91,9 +91,12 @@ public class OotdGetRes {
     @Data
     static class OotdStyleRes {
 
+        private Long styleId;
+
         private String name;
 
         public OotdStyleRes(OotdStyle ootdStyle) {
+            this.styleId = ootdStyle.getStyle().getId();
             this.name = ootdStyle.getStyle().getName();
         }
     }
@@ -101,12 +104,12 @@ public class OotdGetRes {
     @Data
     static class OotdImageRes {
 
-        private String url;
+        private String ootdImage;
 
         private List<OotdImageClothesRes> ootdImageClothesList;
 
         public OotdImageRes(OotdImage ootdImage) {
-            this.url = ootdImage.getImageUrl();
+            this.ootdImage = ootdImage.getImageUrl();
             this.ootdImageClothesList = ootdImage.getOotdImageClothesList().stream()
                     .map(OotdImageClothesRes::new)
                     .collect(Collectors.toList());

--- a/src/main/java/zip/ootd/ootdzip/ootd/data/OotdGetRes.java
+++ b/src/main/java/zip/ootd/ootdzip/ootd/data/OotdGetRes.java
@@ -9,7 +9,6 @@ import lombok.NoArgsConstructor;
 import zip.ootd.ootdzip.brand.data.BrandDto;
 import zip.ootd.ootdzip.category.data.DetailCategory;
 import zip.ootd.ootdzip.clothes.domain.Clothes;
-import zip.ootd.ootdzip.comment.domain.Comment;
 import zip.ootd.ootdzip.ootd.domain.Ootd;
 import zip.ootd.ootdzip.ootdimage.domain.OotdImage;
 import zip.ootd.ootdzip.ootdimageclothe.domain.Coordinate;
@@ -56,8 +55,6 @@ public class OotdGetRes {
 
     private List<OotdStyleRes> styles;
 
-    private List<OotdComment> comment;
-
     public OotdGetRes(Ootd ootd,
             boolean isLike,
             int viewCount,
@@ -88,10 +85,6 @@ public class OotdGetRes {
 
         this.ootdImages = ootd.getOotdImages().stream()
                 .map(OotdImageRes::new)
-                .collect(Collectors.toList());
-
-        this.comment = ootd.getComments().stream()
-                .map(OotdComment::new)
                 .collect(Collectors.toList());
     }
 
@@ -152,60 +145,6 @@ public class OotdGetRes {
                         .parentCategoryName(clothes.getCategory().getParentCategory().getName())
                         .build();
                 this.size = clothes.getSize().getName();
-            }
-        }
-    }
-
-    @Data
-    static class OotdComment {
-
-        private Long id;
-
-        private String userName;
-
-        private String userImage;
-
-        private String content;
-
-        private String timeStamp;
-
-        List<ChildComment> childComment;
-
-        public OotdComment(Comment comment) {
-            this.id = comment.getId();
-            this.userName = comment.getWriter().getName();
-            this.content = comment.getContents();
-            this.userImage = comment.getWriter().getProfileImage();
-            this.timeStamp = comment.compareCreatedTimeAndNow();
-            this.childComment = comment.getChildComments().stream()
-                    .map(ChildComment::new)
-                    .collect(Collectors.toList());
-        }
-
-        @Data
-        static class ChildComment {
-
-            private Long id;
-
-            private String userName;
-
-            private String userImage;
-
-            private String content;
-
-            private String timeStamp;
-
-            private String taggedUserName;
-
-            public ChildComment(Comment comment) {
-                this.id = comment.getId();
-                this.userName = comment.getWriter().getName();
-                this.content = comment.getContents();
-                this.userImage = comment.getWriter().getProfileImage();
-                this.timeStamp = comment.compareCreatedTimeAndNow();
-                if (comment.getTaggedUser() != null) {
-                    this.taggedUserName = comment.getTaggedUser().getName();
-                }
             }
         }
     }

--- a/src/main/java/zip/ootd/ootdzip/ootd/domain/Ootd.java
+++ b/src/main/java/zip/ootd/ootdzip/ootd/domain/Ootd.java
@@ -217,11 +217,6 @@ public class Ootd extends BaseEntity {
         ootdBookmarks.remove(ootdBookmark);
     }
 
-    public void addComment(Comment comment) {
-        comments.add(comment);
-        comment.setOotd(this);
-    }
-
     public void increaseReportCount() {
         this.reportCount += 1;
     }

--- a/src/main/java/zip/ootd/ootdzip/ootd/service/OotdService.java
+++ b/src/main/java/zip/ootd/ootdzip/ootd/service/OotdService.java
@@ -362,7 +362,7 @@ public class OotdService {
                 .map(OotdGetOtherRes::new)
                 .collect(Collectors.toList());
 
-        return new CommonSliceResponse<>(ootdGetOtherResList, pageable, ootds.hasNext());
+        return new CommonSliceResponse<>(ootdGetOtherResList, pageable, ootds.isLast());
     }
 
     /**
@@ -384,6 +384,6 @@ public class OotdService {
                 .map(OotdGetSimilarRes::new)
                 .collect(Collectors.toList());
 
-        return new CommonSliceResponse<>(ootdGetSimilarResList, pageable, ootdImages.hasNext());
+        return new CommonSliceResponse<>(ootdGetSimilarResList, pageable, ootdImages.isLast());
     }
 }

--- a/src/main/java/zip/ootd/ootdzip/ootdbookmark/repository/OotdBookmarkRepository.java
+++ b/src/main/java/zip/ootd/ootdzip/ootdbookmark/repository/OotdBookmarkRepository.java
@@ -15,7 +15,7 @@ public interface OotdBookmarkRepository extends JpaRepository<OotdBookmark, Long
     @Query("SELECT ob from OotdBookmark ob "
             + "join fetch ob.ootd o "
             + "join fetch ob.user u "
-            + "where o.isPrivate = false "
+            + "where (o.isPrivate = false or o.writer.id = :userId) "
             + "and u.id = :userId ")
     Slice<OotdBookmark> findAllByUserId(@Param("userId") Long userId, Pageable pageable);
 }

--- a/src/main/java/zip/ootd/ootdzip/ootdbookmark/service/OotdBookmarkService.java
+++ b/src/main/java/zip/ootd/ootdzip/ootdbookmark/service/OotdBookmarkService.java
@@ -28,11 +28,11 @@ public class OotdBookmarkService {
 
         Pageable pageable = request.toPageable();
         Slice<OotdBookmark> ootdBookmarks = ootdBookmarkRepository.findAllByUserId(loginUser.getId(), pageable);
-        List<OotdBookmarkGetAllRes> ootdBookmarkGetAllResListd = ootdBookmarks.stream()
+        List<OotdBookmarkGetAllRes> ootdBookmarkGetAllResList = ootdBookmarks.stream()
                 .map(OotdBookmarkGetAllRes::of)
                 .collect(Collectors.toList());
 
-        return new CommonSliceResponse<>(ootdBookmarkGetAllResListd, pageable, ootdBookmarks.hasNext());
+        return new CommonSliceResponse<>(ootdBookmarkGetAllResList, pageable, ootdBookmarks.isLast());
     }
 
     public void deleteOotdBookmarks(OotdBookmarkDeleteReq request) {

--- a/src/test/java/zip/ootd/ootdzip/comment/controller/CommentControllerTest.java
+++ b/src/test/java/zip/ootd/ootdzip/comment/controller/CommentControllerTest.java
@@ -6,14 +6,19 @@ import static org.springframework.test.web.servlet.request.MockMvcRequestBuilder
 import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.*;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
 
+import java.util.List;
+
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
 import org.springframework.http.MediaType;
 import org.springframework.test.web.servlet.result.MockMvcResultMatchers;
 
 import zip.ootd.ootdzip.ControllerTestSupport;
 import zip.ootd.ootdzip.comment.data.CommentPostReq;
 import zip.ootd.ootdzip.comment.domain.Comment;
+import zip.ootd.ootdzip.common.response.CommonSliceResponse;
 
 public class CommentControllerTest extends ControllerTestSupport {
 
@@ -167,5 +172,41 @@ public class CommentControllerTest extends ControllerTestSupport {
                 .andExpect(status().isOk())
                 .andExpect(MockMvcResultMatchers.jsonPath("$.statusCode").value(200))
                 .andExpect(MockMvcResultMatchers.jsonPath("$.result").isBoolean());
+    }
+
+    @DisplayName("댓글 전체 조회")
+    @Test
+    void getComments() throws Exception {
+        // given
+        Long ootdId = 1L;
+        Pageable pageable = PageRequest.of(0, 10);
+
+        when(commentService.getComments(any()))
+                .thenReturn(new CommonSliceResponse<>(List.of(), pageable, false));
+
+        // when & then
+        mockMvc.perform(get("/api/v1/comments")
+                        .param("ootdId", ootdId.toString()))
+                .andDo(print())
+                .andExpect(status().isOk())
+                .andExpect(MockMvcResultMatchers.jsonPath("$.statusCode").value(200))
+                .andExpect(MockMvcResultMatchers.jsonPath("$.result").exists());
+    }
+
+    @DisplayName("댓글 전체 조회시 Ootd id 는 필수입니다.")
+    @Test
+    void getCommentsNoOotdId() throws Exception {
+        // given
+        Pageable pageable = PageRequest.of(0, 10);
+
+        when(commentService.getComments(any()))
+                .thenReturn(new CommonSliceResponse<>(List.of(), pageable, false));
+
+        // when & then
+        mockMvc.perform(get("/api/v1/comments"))
+                .andDo(print())
+                .andExpect(status().isNotFound())
+                .andExpect(MockMvcResultMatchers.jsonPath("$.statusCode").value(404))
+                .andExpect(MockMvcResultMatchers.jsonPath("$.errors").isArray());
     }
 }

--- a/src/test/java/zip/ootd/ootdzip/comment/repository/CommentRepositoryTest.java
+++ b/src/test/java/zip/ootd/ootdzip/comment/repository/CommentRepositoryTest.java
@@ -114,7 +114,7 @@ public class CommentRepositoryTest extends IntegrationTestSupport {
         Comment comment2 = createParentCommentBy(ootd, user, "hi3", 2L);
 
         // when
-        Long result = commentRepository.findByMaxGroupId(ootd.getId());
+        Long result = commentRepository.findMaxGroupIdByOotdId(ootd.getId());
 
         // then
         assertThat(result).isEqualTo(2L);
@@ -128,7 +128,7 @@ public class CommentRepositoryTest extends IntegrationTestSupport {
         Ootd ootd = createOotdBy(user, "안녕", false);
 
         // when
-        Long result = commentRepository.findByMaxGroupId(ootd.getId());
+        Long result = commentRepository.findMaxGroupIdByOotdId(ootd.getId());
 
         // then
         assertThat(result).isEqualTo(0L);
@@ -146,7 +146,7 @@ public class CommentRepositoryTest extends IntegrationTestSupport {
         Comment comment2 = createChildCommentBy(comment, ootd, user, user1, "hi3", 0L, 2L);
 
         // when
-        Long result = commentRepository.findByMaxGroupOrder(ootd.getId(), 0L);
+        Long result = commentRepository.findMaxGroupIdByOotdIdAndGroupOrder(ootd.getId(), 0L);
 
         // then
         assertThat(result).isEqualTo(2L);

--- a/src/test/java/zip/ootd/ootdzip/comment/service/CommentServiceTest.java
+++ b/src/test/java/zip/ootd/ootdzip/comment/service/CommentServiceTest.java
@@ -142,13 +142,13 @@ public class CommentServiceTest extends IntegrationTestSupport {
 
         // then
         Comment savedResult = commentRepository.findById(result.getId()).get();
-        assertThat(savedResult).extracting("ootd.id", "contents", "depth"
-                        , "taggedUser.id", "parent.id", "groupId", "groupOrder")
+        assertThat(savedResult).extracting("ootd.id", "contents", "depth",
+                        "taggedUser.id", "parent.id", "groupId", "groupOrder")
                 .contains(ootd.getId(), "안녕하세요1", 2, user1.getId(), comment.getId(), comment.getGroupId(), 1L);
 
         Comment savedResult1 = commentRepository.findById(result1.getId()).get();
-        assertThat(savedResult1).extracting("ootd.id", "contents", "depth"
-                        , "taggedUser.id", "parent.id", "groupId", "groupOrder")
+        assertThat(savedResult1).extracting("ootd.id", "contents", "depth",
+                        "taggedUser.id", "parent.id", "groupId", "groupOrder")
                 .contains(ootd.getId(), "안녕하세요2", 2, user1.getId(), comment1.getId(), comment1.getGroupId(), 1L);
     }
 

--- a/src/test/java/zip/ootd/ootdzip/comment/service/CommentServiceTest.java
+++ b/src/test/java/zip/ootd/ootdzip/comment/service/CommentServiceTest.java
@@ -26,10 +26,13 @@ import zip.ootd.ootdzip.clothes.data.PurchaseStoreType;
 import zip.ootd.ootdzip.clothes.domain.Clothes;
 import zip.ootd.ootdzip.clothes.domain.ClothesColor;
 import zip.ootd.ootdzip.clothes.repository.ClothesRepository;
+import zip.ootd.ootdzip.comment.data.CommentGetAllReq;
+import zip.ootd.ootdzip.comment.data.CommentGetAllRes;
 import zip.ootd.ootdzip.comment.data.CommentPostReq;
 import zip.ootd.ootdzip.comment.domain.Comment;
 import zip.ootd.ootdzip.comment.repository.CommentRepository;
 import zip.ootd.ootdzip.common.exception.CustomException;
+import zip.ootd.ootdzip.common.response.CommonSliceResponse;
 import zip.ootd.ootdzip.ootd.domain.Ootd;
 import zip.ootd.ootdzip.ootd.repository.OotdRepository;
 import zip.ootd.ootdzip.ootdimage.domain.OotdImage;
@@ -89,8 +92,8 @@ public class CommentServiceTest extends IntegrationTestSupport {
 
         // then
         Comment savedResult = commentRepository.findById(result.getId()).get();
-        assertThat(savedResult).extracting("topOotdId", "contents", "depth")
-                .contains(ootd.getId(), "안녕하세요", 1);
+        assertThat(savedResult).extracting("ootd.id", "contents", "depth", "groupId", "groupOrder")
+                .contains(ootd.getId(), "안녕하세요", 1, 0L, 0L);
     }
 
     @DisplayName("댓글 작성시 존재하는 ootd id 이어야 한다.")
@@ -116,7 +119,8 @@ public class CommentServiceTest extends IntegrationTestSupport {
         User user = createUserBy("유저1");
         User user1 = createUserBy("유저2");
         Ootd ootd = createOotdBy(user, "안녕", false);
-        Comment comment = createParentCommentBy(ootd, user, "hi1");
+        Comment comment = createParentCommentBy(ootd, user, "hi1", 0L);
+        Comment comment1 = createParentCommentBy(ootd, user, "hi2", 1L);
 
         CommentPostReq commentPostReq = new CommentPostReq();
         commentPostReq.setOotdId(ootd.getId());
@@ -125,13 +129,27 @@ public class CommentServiceTest extends IntegrationTestSupport {
         commentPostReq.setCommentParentId(comment.getId());
         commentPostReq.setTaggedUserName("유저2");
 
+        CommentPostReq commentPostReq1 = new CommentPostReq();
+        commentPostReq1.setOotdId(ootd.getId());
+        commentPostReq1.setContent("안녕하세요2");
+        commentPostReq1.setParentDepth(1);
+        commentPostReq1.setCommentParentId(comment1.getId());
+        commentPostReq1.setTaggedUserName("유저2");
+
         // when
         Comment result = commentService.saveComment(commentPostReq, user);
+        Comment result1 = commentService.saveComment(commentPostReq1, user);
 
         // then
         Comment savedResult = commentRepository.findById(result.getId()).get();
-        assertThat(savedResult).extracting("topOotdId", "contents", "depth", "taggedUser.id", "parent.id")
-                .contains(ootd.getId(), "안녕하세요1", 2, user1.getId(), comment.getId());
+        assertThat(savedResult).extracting("ootd.id", "contents", "depth"
+                        , "taggedUser.id", "parent.id", "groupId", "groupOrder")
+                .contains(ootd.getId(), "안녕하세요1", 2, user1.getId(), comment.getId(), comment.getGroupId(), 1L);
+
+        Comment savedResult1 = commentRepository.findById(result1.getId()).get();
+        assertThat(savedResult1).extracting("ootd.id", "contents", "depth"
+                        , "taggedUser.id", "parent.id", "groupId", "groupOrder")
+                .contains(ootd.getId(), "안녕하세요2", 2, user1.getId(), comment1.getId(), comment1.getGroupId(), 1L);
     }
 
     @DisplayName("대댓글 작성시 태그된 유저에 대한 값이 있어야 한다.")
@@ -232,13 +250,82 @@ public class CommentServiceTest extends IntegrationTestSupport {
                 CustomException.class);
     }
 
-    private Comment createParentCommentBy(Ootd ootd, User user, String content) {
+    @DisplayName("특정 ootd 에 해당하는 댓글을 조회한다.")
+    @Test
+    void getComments() {
+        // given
+        User user = createUserBy("유저");
+        User user1 = createUserBy("유저1");
+        Ootd ootd = createOotdBy(user, "안녕", false);
+        Comment comment = createParentCommentBy(ootd, user, "hi");
+        Comment comment1 = createParentCommentBy(ootd, user, "hi1", 1L);
+        Comment comment2 = createParentCommentBy(ootd, user, "hi2", 2L);
+
+        Comment comment3 = createChildCommentBy(comment1, ootd, user, user1, "hi3", 1L, 1L);
+        Comment comment4 = createChildCommentBy(comment1, ootd, user, user1, "hi4", 1L, 2L);
+
+        Comment comment5 = createChildCommentBy(comment2, ootd, user, user1, "hi5", 2L, 1L);
+
+        Comment comment6 = createChildCommentBy(comment, ootd, user, user1, "hi6", 0L, 1L);
+
+        CommentGetAllReq commentGetAllReq = new CommentGetAllReq();
+        commentGetAllReq.setOotdId(ootd.getId());
+        commentGetAllReq.setPage(0);
+        commentGetAllReq.setSize(10);
+
+        // when
+        CommonSliceResponse<CommentGetAllRes> results = commentService.getComments(commentGetAllReq);
+
+        // then 댓글이 0->6->1->3->4->2->5 순으로 정렬되어 조회된다.
+        assertThat(results.getContent())
+                .hasSize(7)
+                .extracting("id")
+                .containsExactly(comment.getId(), comment6.getId(), comment1.getId(),
+                        comment3.getId(), comment4.getId(), comment2.getId(), comment5.getId());
+    }
+
+    private Comment createChildCommentBy(Comment parentComment, Ootd ootd, User taggedUser, User user, String content,
+            Long groupId, Long groupOrder) {
 
         Comment comment = Comment.builder()
-                .topOotdId(ootd.getId())
+                .ootd(ootd)
                 .depth(1)
                 .writer(user)
                 .contents(content)
+                .parent(parentComment)
+                .taggedUser(taggedUser)
+                .groupId(groupId)
+                .groupOrder(groupOrder)
+                .build();
+
+        parentComment.setChildCount(parentComment.getChildCount() + 1);
+
+        return commentRepository.save(comment);
+    }
+
+    private Comment createParentCommentBy(Ootd ootd, User user, String content, Long groupId) {
+
+        Comment comment = Comment.builder()
+                .ootd(ootd)
+                .depth(1)
+                .writer(user)
+                .contents(content)
+                .groupId(groupId)
+                .groupOrder(0L)
+                .build();
+
+        return commentRepository.save(comment);
+    }
+
+    private Comment createParentCommentBy(Ootd ootd, User user, String content) {
+
+        Comment comment = Comment.builder()
+                .ootd(ootd)
+                .depth(1)
+                .writer(user)
+                .contents(content)
+                .groupId(0L)
+                .groupOrder(0L)
                 .build();
 
         return commentRepository.save(comment);

--- a/src/test/java/zip/ootd/ootdzip/report/repository/ReportCommentRepositoryTest.java
+++ b/src/test/java/zip/ootd/ootdzip/report/repository/ReportCommentRepositoryTest.java
@@ -96,10 +96,12 @@ class ReportCommentRepositoryTest extends IntegrationTestSupport {
 
     private Comment createCommentBy(User writer, Ootd ootd) {
         Comment comment = Comment.builder()
-                .topOotdId(ootd.getId())
+                .ootd(ootd)
                 .depth(1)
                 .writer(writer)
                 .contents("내용1")
+                .groupOrder(0L)
+                .groupId(0L)
                 .build();
 
         return commentRepository.save(comment);

--- a/src/test/java/zip/ootd/ootdzip/report/service/strategy/ReportCommentStrategyTest.java
+++ b/src/test/java/zip/ootd/ootdzip/report/service/strategy/ReportCommentStrategyTest.java
@@ -172,10 +172,12 @@ class ReportCommentStrategyTest extends IntegrationTestSupport {
 
     private Comment createCommentBy(User writer, Ootd ootd) {
         Comment comment = Comment.builder()
-                .topOotdId(ootd.getId())
+                .ootd(ootd)
                 .depth(1)
                 .writer(writer)
                 .contents("내용1")
+                .groupOrder(0L)
+                .groupId(0L)
                 .build();
 
         return commentRepository.save(comment);


### PR DESCRIPTION
## 변경사항
- CommonSliceResponse 에서 잘못된 변수명 수정
- Bookmark 조회시 해당 ootd 가 private 이어도 본인꺼면 조회가능하게 수정
- OOTD 조회에서 댓글조회 API 분리(담당 프론트 회의를 통해 결정)
- 댓글 작성 방식 변경(분리로 인하여 정렬기준을 다른방식으로 작동하게하기위한 필드추가)

## 참고사항
댓글 작성 방식 변경으로 인한 DB 컬럼 변경 => top_ootd_id 를 삭제하고, 대댓글과 댓글이 소속된 곳을 파악하기위한 groud_id 컬럼과 해당 소속 내에서 작성된 순서를 저장하는 group_order 컬럼이 추가되었습니다.

close #122 