### PR TITLE
Feature/get ootds(#124)

### DIFF
--- a/src/main/java/zip/ootd/ootdzip/ootd/controller/OotdController.java
+++ b/src/main/java/zip/ootd/ootdzip/ootd/controller/OotdController.java
@@ -19,6 +19,8 @@ import lombok.RequiredArgsConstructor;
 import zip.ootd.ootdzip.common.response.ApiResponse;
 import zip.ootd.ootdzip.common.response.CommonSliceResponse;
 import zip.ootd.ootdzip.ootd.data.OotdGetAllRes;
+import zip.ootd.ootdzip.ootd.data.OotdGetByUserReq;
+import zip.ootd.ootdzip.ootd.data.OotdGetByUserRes;
 import zip.ootd.ootdzip.ootd.data.OotdGetOtherReq;
 import zip.ootd.ootdzip.ootd.data.OotdGetOtherRes;
 import zip.ootd.ootdzip.ootd.data.OotdGetRes;
@@ -152,4 +154,5 @@ public class OotdController {
 
         return new ApiResponse<>(response);
     }
+
 }

--- a/src/main/java/zip/ootd/ootdzip/ootd/controller/OotdController.java
+++ b/src/main/java/zip/ootd/ootdzip/ootd/controller/OotdController.java
@@ -57,7 +57,7 @@ public class OotdController {
     public ApiResponse<Boolean> updateOotdContentsAndIsPrivate(@PathVariable Long id,
             @RequestBody @Valid OotdPatchReq request) {
 
-        ootdService.updateContentsAndIsPrivate(id ,request);
+        ootdService.updateContentsAndIsPrivate(id, request);
 
         return new ApiResponse<>(true);
     }
@@ -155,4 +155,12 @@ public class OotdController {
         return new ApiResponse<>(response);
     }
 
+    @Operation(summary = "특정 유저 ootd 조회", description = "user id 를 주면 해당 id에 유저 ootd 들을 반환 api")
+    @GetMapping("")
+    public ApiResponse<CommonSliceResponse<OotdGetByUserRes>> getUserOotd(@Valid OotdGetByUserReq request) {
+
+        CommonSliceResponse<OotdGetByUserRes> response = ootdService.getOotdByUser(request);
+
+        return new ApiResponse<>(response);
+    }
 }

--- a/src/main/java/zip/ootd/ootdzip/ootd/controller/OotdController.java
+++ b/src/main/java/zip/ootd/ootdzip/ootd/controller/OotdController.java
@@ -51,19 +51,21 @@ public class OotdController {
     }
 
     @Operation(summary = "ootd 공개/비공개 여부 수정", description = "ootd 공개여부만 수정하는 api")
-    @PatchMapping("")
-    public ApiResponse<Boolean> updateOotdContentsAndIsPrivate(@RequestBody @Valid OotdPatchReq request) {
+    @PatchMapping("/{id}")
+    public ApiResponse<Boolean> updateOotdContentsAndIsPrivate(@PathVariable Long id,
+            @RequestBody @Valid OotdPatchReq request) {
 
-        ootdService.updateContentsAndIsPrivate(request);
+        ootdService.updateContentsAndIsPrivate(id ,request);
 
         return new ApiResponse<>(true);
     }
 
     @Operation(summary = "ootd 전체 수정", description = "ootd 게시글 전체 수정 api")
-    @PutMapping("")
-    public ApiResponse<Boolean> updateOotdAll(@RequestBody @Valid OotdPutReq request) {
+    @PutMapping("/{id}")
+    public ApiResponse<Boolean> updateOotdAll(@PathVariable Long id,
+            @RequestBody @Valid OotdPutReq request) {
 
-        ootdService.updateAll(request);
+        ootdService.updateAll(id, request);
 
         return new ApiResponse<>(true);
     }

--- a/src/main/java/zip/ootd/ootdzip/ootd/data/OotdGetByUserReq.java
+++ b/src/main/java/zip/ootd/ootdzip/ootd/data/OotdGetByUserReq.java
@@ -1,0 +1,12 @@
+package zip.ootd.ootdzip.ootd.data;
+
+import jakarta.validation.constraints.NotNull;
+import lombok.Data;
+import zip.ootd.ootdzip.common.request.CommonPageRequest;
+
+@Data
+public class OotdGetByUserReq extends CommonPageRequest {
+
+    @NotNull(message = "마이페이지 ootd 조회시 조회할 user id 는 필수입니다.")
+    private Long userId;
+}

--- a/src/main/java/zip/ootd/ootdzip/ootd/data/OotdGetByUserRes.java
+++ b/src/main/java/zip/ootd/ootdzip/ootd/data/OotdGetByUserRes.java
@@ -1,0 +1,17 @@
+package zip.ootd.ootdzip.ootd.data;
+
+import lombok.Data;
+import zip.ootd.ootdzip.ootd.domain.Ootd;
+
+@Data
+public class OotdGetByUserRes {
+
+    private Long id;
+
+    private String image;
+
+    public OotdGetByUserRes(Ootd ootd) {
+        this.id = ootd.getId();
+        this.image = ootd.getOotdImages().get(0).getImageUrl();
+    }
+}

--- a/src/main/java/zip/ootd/ootdzip/ootd/data/OotdPatchReq.java
+++ b/src/main/java/zip/ootd/ootdzip/ootd/data/OotdPatchReq.java
@@ -8,8 +8,5 @@ import lombok.Data;
 public class OotdPatchReq {
 
     @NotNull
-    private Long id;
-
-    @NotNull
     private Boolean isPrivate;
 }

--- a/src/main/java/zip/ootd/ootdzip/ootd/data/OotdPutReq.java
+++ b/src/main/java/zip/ootd/ootdzip/ootd/data/OotdPutReq.java
@@ -11,9 +11,6 @@ import lombok.Data;
 @Data
 public class OotdPutReq {
 
-    @NotNull
-    private Long id;
-
     @Size(max = 3000, message = "게시글은 최대 3000자 입니다.")
     private String content;
 

--- a/src/main/java/zip/ootd/ootdzip/ootd/repository/OotdRepository.java
+++ b/src/main/java/zip/ootd/ootdzip/ootd/repository/OotdRepository.java
@@ -22,7 +22,8 @@ public interface OotdRepository extends JpaRepository<Ootd, Long> {
 
     @Query("SELECT o from Ootd o where o.isPrivate = false "
             + "and o.writer.id = :userId "
-            + "and o.id <> :ootdId")
+            + "and o.id <> :ootdId "
+            + "and o.isPrivate = false ")
     Slice<Ootd> findAllByUserIdAndOotdId(@Param("userId") Long userId,
             @Param("ootdId") Long ootdId,
             Pageable pageable);

--- a/src/main/java/zip/ootd/ootdzip/ootd/service/OotdService.java
+++ b/src/main/java/zip/ootd/ootdzip/ootd/service/OotdService.java
@@ -79,16 +79,16 @@ public class OotdService {
         return ootd;
     }
 
-    public void updateContentsAndIsPrivate(OotdPatchReq request) {
+    public void updateContentsAndIsPrivate(Long id, OotdPatchReq request) {
 
-        Ootd ootd = ootdRepository.findById(request.getId()).orElseThrow();
+        Ootd ootd = ootdRepository.findById(id).orElseThrow();
 
         ootd.updateIsPrivate(request.getIsPrivate());
     }
 
-    public void updateAll(OotdPutReq request) {
+    public void updateAll(Long id, OotdPutReq request) {
 
-        Ootd ootd = ootdRepository.findById(request.getId()).orElseThrow();
+        Ootd ootd = ootdRepository.findById(id).orElseThrow();
 
         List<OotdImage> ootdImages = request.getOotdImages().stream().map(ootdImage -> {
             List<OotdImageClothes> ootdImageClothesList = ootdImage.getClothesTags().stream().map(clothesTag -> {

--- a/src/main/java/zip/ootd/ootdzip/ootd/service/OotdService.java
+++ b/src/main/java/zip/ootd/ootdzip/ootd/service/OotdService.java
@@ -352,6 +352,7 @@ public class OotdService {
 
     /**
      * OOTD 상세 조회시, 현재 OOTD 작성자의 다른 OOTD 정보를 제공한다.
+     * 본인 조회시에도 비공개글은 조회되지 ㅏㅇㄴ흣ㅂ니다.
      */
     public CommonSliceResponse<OotdGetOtherRes> getOotdOther(OotdGetOtherReq request) {
 
@@ -370,6 +371,7 @@ public class OotdService {
 
     /**
      * OOTD 상세 조회시, 현재 OOTD 와 동일한 스타일의 다른 OOTD 를 제공합니다.
+     * 본인 조회시에도 비공개글은 조회되지 않습니다.
      */
     public CommonSliceResponse<OotdGetSimilarRes> getOotdSimilar(OotdGetSimilarReq request) {
 
@@ -390,4 +392,21 @@ public class OotdService {
         return new CommonSliceResponse<>(ootdGetSimilarResList, pageable, ootdImages.isLast());
     }
 
+    /**
+     * 마이페이지에서 OOTD 조회시 해당 유저가 가진 OOTD 정보를 제공합니다.
+     * 본인 조회시, 비공개글 조회가 됩니다.
+     */
+    public CommonSliceResponse<OotdGetByUserRes> getOotdByUser(OotdGetByUserReq request) {
+
+        Long userId = request.getUserId();
+        Pageable pageable = request.toPageable();
+
+        Slice<Ootd> ootds = ootdRepository.findAllByUserId(userId, pageable);
+
+        List<OotdGetByUserRes> ootdGetByUserResList = ootds.stream()
+                .map(OotdGetByUserRes::new)
+                .collect(Collectors.toList());
+
+        return new CommonSliceResponse<>(ootdGetByUserResList, pageable, ootds.isLast());
+    }
 }

--- a/src/main/java/zip/ootd/ootdzip/ootd/service/OotdService.java
+++ b/src/main/java/zip/ootd/ootdzip/ootd/service/OotdService.java
@@ -23,6 +23,8 @@ import zip.ootd.ootdzip.common.exception.CustomException;
 import zip.ootd.ootdzip.common.exception.code.ErrorCode;
 import zip.ootd.ootdzip.common.response.CommonSliceResponse;
 import zip.ootd.ootdzip.ootd.data.OotdGetAllRes;
+import zip.ootd.ootdzip.ootd.data.OotdGetByUserReq;
+import zip.ootd.ootdzip.ootd.data.OotdGetByUserRes;
 import zip.ootd.ootdzip.ootd.data.OotdGetOtherReq;
 import zip.ootd.ootdzip.ootd.data.OotdGetOtherRes;
 import zip.ootd.ootdzip.ootd.data.OotdGetRes;
@@ -387,4 +389,5 @@ public class OotdService {
 
         return new CommonSliceResponse<>(ootdGetSimilarResList, pageable, ootdImages.isLast());
     }
+
 }

--- a/src/main/java/zip/ootd/ootdzip/ootdimage/repository/OotdImageRepository.java
+++ b/src/main/java/zip/ootd/ootdzip/ootdimage/repository/OotdImageRepository.java
@@ -31,7 +31,8 @@ public interface OotdImageRepository extends JpaRepository<OotdImage, Long> {
     @Query("SELECT DISTINCT oi FROM OotdImage oi "
             + "JOIN FETCH oi.ootd o "
             + "JOIN o.styles os ON os.style IN (:styles) "
-            + "AND o.id <> :ootdId ")
+            + "AND o.id <> :ootdId "
+            + "AND o.isPrivate = false ")
     Slice<OotdImage> findByStyles(
             @Param("ootdId") Long ootdId,
             @Param("styles") List<Style> styles,

--- a/src/test/java/zip/ootd/ootdzip/ootd/controller/OotdControllerTest.java
+++ b/src/test/java/zip/ootd/ootdzip/ootd/controller/OotdControllerTest.java
@@ -491,4 +491,24 @@ public class OotdControllerTest extends ControllerTestSupport {
                 .andExpect(MockMvcResultMatchers.jsonPath("$.statusCode").value(200))
                 .andExpect(MockMvcResultMatchers.jsonPath("$.result").exists());
     }
+
+    @DisplayName("선택한 유저 OOTD 게시글 조회")
+    @Test
+    void getUserOotd() throws Exception {
+        // given
+        Long userId = 1L;
+        Pageable pageable = PageRequest.of(0, 10);
+
+        when(ootdService.getOotdByUser(any()))
+                .thenReturn(new CommonSliceResponse<>(List.of(), pageable, true));
+
+        // when & then
+        mockMvc.perform(get("/api/v1/ootd")
+                        .param("userId", Long.toString(userId)))
+                .andDo(print())
+                .andExpect(status().isOk())
+                .andExpect(MockMvcResultMatchers.jsonPath("$.statusCode").value(200))
+                .andExpect(MockMvcResultMatchers.jsonPath("$.result").exists());
+    }
+
 }

--- a/src/test/java/zip/ootd/ootdzip/ootd/controller/OotdControllerTest.java
+++ b/src/test/java/zip/ootd/ootdzip/ootd/controller/OotdControllerTest.java
@@ -173,11 +173,11 @@ public class OotdControllerTest extends ControllerTestSupport {
     void updateContentAndIsPrivate() throws Exception {
         // given
         OotdPatchReq ootdPatchReq = new OotdPatchReq();
-        ootdPatchReq.setId(1L);
         ootdPatchReq.setIsPrivate(true);
 
         // when & then
-        mockMvc.perform(patch("/api/v1/ootd").content(objectMapper.writeValueAsString(ootdPatchReq))
+        mockMvc.perform(patch("/api/v1/ootd/{id}", 1L)
+                        .content(objectMapper.writeValueAsString(ootdPatchReq))
                         .contentType(MediaType.APPLICATION_JSON))
                 .andDo(print())
                 .andExpect(status().isOk())
@@ -185,31 +185,15 @@ public class OotdControllerTest extends ControllerTestSupport {
                 .andExpect(MockMvcResultMatchers.jsonPath("$.result").isBoolean());
     }
 
-    @DisplayName("OOTD 공개여부 수정시 id 는 필수입니다.")
-    @Test
-    void updateContentAndIsPrivateWithoutId() throws Exception {
-        // given
-        OotdPatchReq ootdPatchReq = new OotdPatchReq();
-        ootdPatchReq.setIsPrivate(true);
-
-        // when & then
-        mockMvc.perform(patch("/api/v1/ootd").content(objectMapper.writeValueAsString(ootdPatchReq))
-                        .contentType(MediaType.APPLICATION_JSON))
-                .andDo(print())
-                .andExpect(status().isNotFound())
-                .andExpect(MockMvcResultMatchers.jsonPath("$.statusCode").value(404))
-                .andExpect(MockMvcResultMatchers.jsonPath("$.errors").isArray());
-    }
-
     @DisplayName("OOTD 공개여부 수정시 공개여부는 필수입니다.")
     @Test
     void updateContentAndIsPrivateWithoutIsPrivate() throws Exception {
         // given
         OotdPatchReq ootdPatchReq = new OotdPatchReq();
-        ootdPatchReq.setId(1L);
 
         // when & then
-        mockMvc.perform(patch("/api/v1/ootd").content(objectMapper.writeValueAsString(ootdPatchReq))
+        mockMvc.perform(patch("/api/v1/ootd/{id}", 1L)
+                        .content(objectMapper.writeValueAsString(ootdPatchReq))
                         .contentType(MediaType.APPLICATION_JSON))
                 .andDo(print())
                 .andExpect(status().isNotFound())
@@ -240,56 +224,19 @@ public class OotdControllerTest extends ControllerTestSupport {
         ootdImageReq.setClothesTags(Arrays.asList(clothesTagReq, clothesTagReq1));
 
         OotdPutReq ootdPutReq = new OotdPutReq();
-        ootdPutReq.setId(1L);
         ootdPutReq.setIsPrivate(false);
         ootdPutReq.setContent("테스트");
         ootdPutReq.setStyles(Arrays.asList(1L, 2L));
         ootdPutReq.setOotdImages(Arrays.asList(ootdImageReq));
 
         // when & then
-        mockMvc.perform(put("/api/v1/ootd").content(objectMapper.writeValueAsString(ootdPutReq))
+        mockMvc.perform(put("/api/v1/ootd/{id}", 1L)
+                        .content(objectMapper.writeValueAsString(ootdPutReq))
                         .contentType(MediaType.APPLICATION_JSON))
                 .andDo(print())
                 .andExpect(status().isOk())
                 .andExpect(MockMvcResultMatchers.jsonPath("$.statusCode").value(200))
                 .andExpect(MockMvcResultMatchers.jsonPath("$.result").isBoolean());
-    }
-
-    @DisplayName("OOTD 게시글 전체수정시 id 는 필수입니다.")
-    @Test
-    void updateAllWithoutId() throws Exception {
-        // given
-        OotdPutReq.OotdImageReq.ClothesTagReq clothesTagReq = new OotdPutReq.OotdImageReq.ClothesTagReq();
-        clothesTagReq.setClothesId(1L);
-        clothesTagReq.setDeviceWidth(100L);
-        clothesTagReq.setDeviceHeight(50L);
-        clothesTagReq.setXRate("22.33");
-        clothesTagReq.setYRate("33.44");
-
-        OotdPutReq.OotdImageReq.ClothesTagReq clothesTagReq1 = new OotdPutReq.OotdImageReq.ClothesTagReq();
-        clothesTagReq1.setClothesId(2L);
-        clothesTagReq1.setDeviceWidth(100L);
-        clothesTagReq1.setDeviceHeight(50L);
-        clothesTagReq1.setXRate("33.44");
-        clothesTagReq1.setYRate("44.55");
-
-        OotdPutReq.OotdImageReq ootdImageReq = new OotdPutReq.OotdImageReq();
-        ootdImageReq.setOotdImage("input_image_url");
-        ootdImageReq.setClothesTags(Arrays.asList(clothesTagReq, clothesTagReq1));
-
-        OotdPutReq ootdPutReq = new OotdPutReq();
-        ootdPutReq.setIsPrivate(false);
-        ootdPutReq.setContent("테스트");
-        ootdPutReq.setStyles(Arrays.asList(1L, 2L));
-        ootdPutReq.setOotdImages(Arrays.asList(ootdImageReq));
-
-        // when & then
-        mockMvc.perform(put("/api/v1/ootd").content(objectMapper.writeValueAsString(ootdPutReq))
-                        .contentType(MediaType.APPLICATION_JSON))
-                .andDo(print())
-                .andExpect(status().isNotFound())
-                .andExpect(MockMvcResultMatchers.jsonPath("$.statusCode").value(404))
-                .andExpect(MockMvcResultMatchers.jsonPath("$.errors").isArray());
     }
 
     @DisplayName("OOTD 게시글 전체수정시 공개여부는 필수입니다.")
@@ -315,13 +262,13 @@ public class OotdControllerTest extends ControllerTestSupport {
         ootdImageReq.setClothesTags(Arrays.asList(clothesTagReq, clothesTagReq1));
 
         OotdPutReq ootdPutReq = new OotdPutReq();
-        ootdPutReq.setId(1L);
         ootdPutReq.setContent("테스트");
         ootdPutReq.setStyles(Arrays.asList(1L, 2L));
         ootdPutReq.setOotdImages(Arrays.asList(ootdImageReq));
 
         // when & then
-        mockMvc.perform(put("/api/v1/ootd").content(objectMapper.writeValueAsString(ootdPutReq))
+        mockMvc.perform(put("/api/v1/ootd/{id}", 1L)
+                        .content(objectMapper.writeValueAsString(ootdPutReq))
                         .contentType(MediaType.APPLICATION_JSON))
                 .andDo(print())
                 .andExpect(status().isNotFound())
@@ -334,13 +281,13 @@ public class OotdControllerTest extends ControllerTestSupport {
     void updateAllWithoutOotdImages() throws Exception {
         // given
         OotdPutReq ootdPutReq = new OotdPutReq();
-        ootdPutReq.setId(1L);
         ootdPutReq.setIsPrivate(false);
         ootdPutReq.setContent("테스트");
         ootdPutReq.setStyles(Arrays.asList(1L, 2L));
 
         // when & then
-        mockMvc.perform(put("/api/v1/ootd").content(objectMapper.writeValueAsString(ootdPutReq))
+        mockMvc.perform(put("/api/v1/ootd/{id}", 1L)
+                        .content(objectMapper.writeValueAsString(ootdPutReq))
                         .contentType(MediaType.APPLICATION_JSON))
                 .andDo(print())
                 .andExpect(status().isNotFound())
@@ -370,14 +317,14 @@ public class OotdControllerTest extends ControllerTestSupport {
         ootdImageReq.setClothesTags(Arrays.asList(clothesTagReq, clothesTagReq1));
 
         OotdPutReq ootdPutReq = new OotdPutReq();
-        ootdPutReq.setId(1L);
         ootdPutReq.setIsPrivate(false);
         ootdPutReq.setContent("테스트");
         ootdPutReq.setStyles(Arrays.asList(1L, 2L));
         ootdPutReq.setOotdImages(Arrays.asList(ootdImageReq));
 
         // when & then
-        mockMvc.perform(put("/api/v1/ootd").content(objectMapper.writeValueAsString(ootdPutReq))
+        mockMvc.perform(put("/api/v1/ootd/{id}", 1L)
+                        .content(objectMapper.writeValueAsString(ootdPutReq))
                         .contentType(MediaType.APPLICATION_JSON))
                 .andDo(print())
                 .andExpect(status().isNotFound())
@@ -408,7 +355,6 @@ public class OotdControllerTest extends ControllerTestSupport {
         ootdImageReq.setClothesTags(Arrays.asList(clothesTagReq, clothesTagReq1));
 
         OotdPutReq ootdPutReq = new OotdPutReq();
-        ootdPutReq.setId(1L);
         ootdPutReq.setIsPrivate(false);
 
         StringBuilder content = new StringBuilder();
@@ -425,7 +371,8 @@ public class OotdControllerTest extends ControllerTestSupport {
         ootdPutReq.setOotdImages(Arrays.asList(ootdImageReq));
 
         // when & then
-        mockMvc.perform(put("/api/v1/ootd").content(objectMapper.writeValueAsString(ootdPutReq))
+        mockMvc.perform(put("/api/v1/ootd/{id}", 1L)
+                        .content(objectMapper.writeValueAsString(ootdPutReq))
                         .contentType(MediaType.APPLICATION_JSON))
                 .andDo(print())
                 .andExpect(status().isNotFound())

--- a/src/test/java/zip/ootd/ootdzip/ootd/service/OotdServiceTest.java
+++ b/src/test/java/zip/ootd/ootdzip/ootd/service/OotdServiceTest.java
@@ -154,10 +154,9 @@ public class OotdServiceTest extends IntegrationTestSupport {
 
         OotdPatchReq ootdPatchReq = new OotdPatchReq();
         ootdPatchReq.setIsPrivate(true);
-        ootdPatchReq.setId(ootd.getId());
 
         // when
-        ootdService.updateContentsAndIsPrivate(ootdPatchReq);
+        ootdService.updateContentsAndIsPrivate(ootd.getId(), ootdPatchReq);
 
         // then
         assertThat(ootd).extracting("id", "isPrivate")
@@ -199,12 +198,11 @@ public class OotdServiceTest extends IntegrationTestSupport {
         OotdPutReq ootdPutReq = new OotdPutReq();
         ootdPutReq.setContent("잘가");
         ootdPutReq.setIsPrivate(true);
-        ootdPutReq.setId(ootd.getId());
         ootdPutReq.setOotdImages(Arrays.asList(ootdImageReq));
         ootdPutReq.setStyles(Arrays.asList(savedStyle.getId(), savedStyle1.getId()));
 
         // when
-        ootdService.updateAll(ootdPutReq);
+        ootdService.updateAll(ootd.getId(), ootdPutReq);
 
         // then
         Ootd savedResult = ootdRepository.findById(ootd.getId()).get();


### PR DESCRIPTION
## 변경사항

- patch, put, delete 에 대해 접근하는 id 는 url 에 명시(슬랙에서 회의 결과)
- 비슷한 ootd, 다른 ootd 에서 비공개글은 접근이 안되도록 수정(본인이어도 불가)
- 마이페이지를에서 사용하는 특정 사용자 ootd 조회 API 개발(본인일시 비공개글이 조회가능)

close #124 