### PR TITLE
마이페이지 OOTD 조회수정 및 래퍼타입변경

### DIFF
--- a/src/main/java/zip/ootd/ootdzip/comment/data/CommentGetAllRes.java
+++ b/src/main/java/zip/ootd/ootdzip/comment/data/CommentGetAllRes.java
@@ -24,7 +24,7 @@ public class CommentGetAllRes {
 
     private String taggedUserName;
 
-    private int depth;
+    private Integer depth;
 
     private Long parentId;
 

--- a/src/main/java/zip/ootd/ootdzip/comment/data/CommentGetAllRes.java
+++ b/src/main/java/zip/ootd/ootdzip/comment/data/CommentGetAllRes.java
@@ -39,10 +39,10 @@ public class CommentGetAllRes {
                 .userImage(comment.getWriter().getProfileImage())
                 .content(comment.getContents())
                 .timeStamp(comment.compareCreatedTimeAndNow())
-                .taggedUserName(comment.getTaggedUser() == null ? null : comment.getTaggedUser().getName())
+                .taggedUserName(comment.getTaggedUserName())
                 .depth(comment.getDepth())
                 .groupId(comment.getGroupId())
-                .parentId(comment.getParent() == null ? null : comment.getParent().getId())
+                .parentId(comment.getParentCommentId())
                 .build();
     }
 }

--- a/src/main/java/zip/ootd/ootdzip/comment/domain/Comment.java
+++ b/src/main/java/zip/ootd/ootdzip/comment/domain/Comment.java
@@ -160,4 +160,22 @@ public class Comment extends BaseEntity {
             parent.setChildCount(parent.getChildCount() - 1);
         }
     }
+
+    // == Custom Getter == //
+
+    public String getTaggedUserName() {
+        if (taggedUser == null) {
+            return "";
+        }
+
+        return taggedUser.getName();
+    }
+
+    public Long getParentCommentId() {
+        if (parent == null) {
+            return null;
+        }
+
+        return parent.getId();
+    }
 }

--- a/src/main/java/zip/ootd/ootdzip/common/response/CommonSliceResponse.java
+++ b/src/main/java/zip/ootd/ootdzip/common/response/CommonSliceResponse.java
@@ -15,7 +15,7 @@ public class CommonSliceResponse<T> {
 
     private Integer size = 30;
 
-    private boolean isLast;
+    private Boolean isLast;
 
     public CommonSliceResponse(List<T> content, Pageable pageable, boolean isLast) {
         this.content = content;

--- a/src/main/java/zip/ootd/ootdzip/ootd/controller/OotdController.java
+++ b/src/main/java/zip/ootd/ootdzip/ootd/controller/OotdController.java
@@ -159,7 +159,8 @@ public class OotdController {
     @GetMapping("")
     public ApiResponse<CommonSliceResponse<OotdGetByUserRes>> getUserOotd(@Valid OotdGetByUserReq request) {
 
-        CommonSliceResponse<OotdGetByUserRes> response = ootdService.getOotdByUser(request);
+        CommonSliceResponse<OotdGetByUserRes> response = ootdService.getOotdByUser(userService.getAuthenticatiedUser(),
+                request);
 
         return new ApiResponse<>(response);
     }

--- a/src/main/java/zip/ootd/ootdzip/ootd/data/OotdGetAllRes.java
+++ b/src/main/java/zip/ootd/ootdzip/ootd/data/OotdGetAllRes.java
@@ -15,9 +15,9 @@ public class OotdGetAllRes {
 
     private Long id;
 
-    private boolean isLike;
+    private Boolean isLike;
 
-    private boolean isBookmark;
+    private Boolean isBookmark;
 
     private String userName;
 
@@ -29,13 +29,13 @@ public class OotdGetAllRes {
 
     private String contents;
 
-    private int viewCount;
+    private Integer viewCount;
 
-    private int reportCount;
+    private Integer reportCount;
 
-    private int likeCount;
+    private Integer likeCount;
 
-    private boolean isFollowing;
+    private Boolean isFollowing;
 
     private LocalDateTime createAt;
 
@@ -44,9 +44,9 @@ public class OotdGetAllRes {
     private List<OotdStyleRes> styles;
 
     public OotdGetAllRes(Ootd ootd,
-            boolean isLike,
-            int viewCount,
-            int likeCount,
+            Boolean isLike,
+            Integer viewCount,
+            Integer likeCount,
             User loginUser) {
 
         this.isLike = isLike;

--- a/src/main/java/zip/ootd/ootdzip/ootd/data/OotdGetByUserRes.java
+++ b/src/main/java/zip/ootd/ootdzip/ootd/data/OotdGetByUserRes.java
@@ -12,6 +12,6 @@ public class OotdGetByUserRes {
 
     public OotdGetByUserRes(Ootd ootd) {
         this.id = ootd.getId();
-        this.image = ootd.getOotdImages().get(0).getImageUrl();
+        this.image = ootd.getFirstImage();
     }
 }

--- a/src/main/java/zip/ootd/ootdzip/ootd/data/OotdGetOtherRes.java
+++ b/src/main/java/zip/ootd/ootdzip/ootd/data/OotdGetOtherRes.java
@@ -14,6 +14,6 @@ public class OotdGetOtherRes {
 
     public OotdGetOtherRes(Ootd ootd) {
         this.id = ootd.getId();
-        this.image = ootd.getOotdImages().get(0).getImageUrl();
+        this.image = ootd.getFirstImage();
     }
 }

--- a/src/main/java/zip/ootd/ootdzip/ootd/data/OotdGetRes.java
+++ b/src/main/java/zip/ootd/ootdzip/ootd/data/OotdGetRes.java
@@ -25,15 +25,15 @@ public class OotdGetRes {
 
     private String contents;
 
-    private boolean isLike;
+    private Boolean isLike;
 
-    private int viewCount;
+    private Integer viewCount;
 
-    private int reportCount;
+    private Integer reportCount;
 
-    private int likeCount;
+    private Integer likeCount;
 
-    private boolean isBookmark;
+    private Boolean isBookmark;
 
     private String userName;
 
@@ -47,18 +47,18 @@ public class OotdGetRes {
 
     private LocalDateTime createAt;
 
-    private boolean isFollowing;
+    private Boolean isFollowing;
 
-    private boolean isPrivate;
+    private Boolean isPrivate;
 
     private List<OotdImageRes> ootdImages;
 
     private List<OotdStyleRes> styles;
 
     public OotdGetRes(Ootd ootd,
-            boolean isLike,
-            int viewCount,
-            int likeCount,
+            Boolean isLike,
+            Integer viewCount,
+            Integer likeCount,
             User loginUser) {
 
         this.isLike = isLike;

--- a/src/main/java/zip/ootd/ootdzip/ootd/domain/Ootd.java
+++ b/src/main/java/zip/ootd/ootdzip/ootd/domain/Ootd.java
@@ -188,6 +188,14 @@ public class Ootd extends BaseEntity {
         this.deletedAt = LocalDateTime.now();
     }
 
+    // == Custom Getter == //
+    public String getFirstImage() {
+        if (ootdImages.isEmpty()) {
+            throw new IllegalArgumentException("저장된 OOTD 이미지가없는 OOTD 를 조회했습니다.");
+        }
+        return ootdImages.get(0).getImageUrl();
+    }
+
     // == 연관관계 메서드 == //
     public void addOotdImage(OotdImage ootdImage) {
         ootdImages.add(ootdImage);

--- a/src/main/java/zip/ootd/ootdzip/ootd/repository/OotdRepository.java
+++ b/src/main/java/zip/ootd/ootdzip/ootd/repository/OotdRepository.java
@@ -17,6 +17,12 @@ public interface OotdRepository extends JpaRepository<Ootd, Long> {
     @Query("SELECT o from Ootd o where (o.isPrivate = false or o.writer.id = :userId) ")
     Slice<Ootd> findAllByUserId(@Param("userId") Long userId, Pageable pageable);
 
+    @Query("SELECT o from Ootd o where o.writer.id = :userId "
+            + "and (o.isPrivate = false or o.writer.id = :loginUserId) ")
+    Slice<Ootd> findAllByUserIdAndLoginUserId(@Param("userId") Long userId,
+            @Param("loginUserId") Long loginUserId,
+            Pageable pageable);
+
     @Query("SELECT o from Ootd o where o.id in(:ootdIds)")
     Slice<Ootd> findAllByIds(@Param("ootdIds") List<Long> ootdIds, Pageable pageable);
 

--- a/src/main/java/zip/ootd/ootdzip/ootd/service/OotdService.java
+++ b/src/main/java/zip/ootd/ootdzip/ootd/service/OotdService.java
@@ -394,14 +394,15 @@ public class OotdService {
 
     /**
      * 마이페이지에서 OOTD 조회시 해당 유저가 가진 OOTD 정보를 제공합니다.
-     * 본인 조회시, 비공개글 조회가 됩니다.
+     * 본인 조회시, 비공개글 조회가 가능합니다. 그래서 loginUser 정보를 받아 검증할 필요가 있습니다.
      */
-    public CommonSliceResponse<OotdGetByUserRes> getOotdByUser(OotdGetByUserReq request) {
+    public CommonSliceResponse<OotdGetByUserRes> getOotdByUser(User loginUser, OotdGetByUserReq request) {
 
         Long userId = request.getUserId();
+        Long loginUserId = loginUser.getId();
         Pageable pageable = request.toPageable();
 
-        Slice<Ootd> ootds = ootdRepository.findAllByUserId(userId, pageable);
+        Slice<Ootd> ootds = ootdRepository.findAllByUserIdAndLoginUserId(userId, loginUserId, pageable);
 
         List<OotdGetByUserRes> ootdGetByUserResList = ootds.stream()
                 .map(OotdGetByUserRes::new)

--- a/src/test/java/zip/ootd/ootdzip/ootd/controller/OotdControllerTest.java
+++ b/src/test/java/zip/ootd/ootdzip/ootd/controller/OotdControllerTest.java
@@ -499,7 +499,7 @@ public class OotdControllerTest extends ControllerTestSupport {
         Long userId = 1L;
         Pageable pageable = PageRequest.of(0, 10);
 
-        when(ootdService.getOotdByUser(any()))
+        when(ootdService.getOotdByUser(any(), any()))
                 .thenReturn(new CommonSliceResponse<>(List.of(), pageable, true));
 
         // when & then

--- a/src/test/java/zip/ootd/ootdzip/ootd/service/OotdServiceTest.java
+++ b/src/test/java/zip/ootd/ootdzip/ootd/service/OotdServiceTest.java
@@ -521,10 +521,13 @@ public class OotdServiceTest extends IntegrationTestSupport {
     void getOotdByUser() {
         // given
         User user = createUserBy("유저");
+        User user1 = createUserBy("유저1");
         Ootd ootd = createOotdBy(user, "안녕", false);
         Ootd ootd1 = createOotdBy(user, "안녕", false);
         Ootd ootd2 = createOotdBy(user, "안녕", true);
         Ootd ootd3 = createOotdBy(user, "안녕", true);
+        Ootd ootd4 = createOotdBy(user1, "안녕", false);
+        Ootd ootd5 = createOotdBy(user1, "안녕", true);
 
         OotdGetByUserReq ootdGetByUserReq = new OotdGetByUserReq();
         ootdGetByUserReq.setUserId(user.getId());
@@ -534,7 +537,7 @@ public class OotdServiceTest extends IntegrationTestSupport {
         ootdGetByUserReq.setSortDirection(Sort.Direction.DESC);
 
         // when
-        CommonSliceResponse<OotdGetByUserRes> result = ootdService.getOotdByUser(ootdGetByUserReq);
+        CommonSliceResponse<OotdGetByUserRes> result = ootdService.getOotdByUser(user, ootdGetByUserReq);
 
         // then
         // ootd 는 작성시간 내림차순으로 정렬된다.
@@ -554,16 +557,18 @@ public class OotdServiceTest extends IntegrationTestSupport {
         Ootd ootd1 = createOotdBy(user, "안녕", false);
         Ootd ootd2 = createOotdBy(user, "안녕", true);
         Ootd ootd3 = createOotdBy(user, "안녕", true);
+        Ootd ootd4 = createOotdBy(user1, "안녕", false);
+        Ootd ootd5 = createOotdBy(user1, "안녕", true);
 
         OotdGetByUserReq ootdGetByUserReq = new OotdGetByUserReq();
-        ootdGetByUserReq.setUserId(user1.getId());
+        ootdGetByUserReq.setUserId(user.getId());
         ootdGetByUserReq.setPage(0);
         ootdGetByUserReq.setSize(10);
         ootdGetByUserReq.setSortCriteria("createdAt");
         ootdGetByUserReq.setSortDirection(Sort.Direction.DESC);
 
         // when
-        CommonSliceResponse<OotdGetByUserRes> result = ootdService.getOotdByUser(ootdGetByUserReq);
+        CommonSliceResponse<OotdGetByUserRes> result = ootdService.getOotdByUser(user1, ootdGetByUserReq);
 
         // then
         // ootd 는 작성시간 내림차순으로 정렬된다.


### PR DESCRIPTION
## 참고사항

- 마이페이지 OOTD 조회시 다른 사람 OOTD 도 조회되는 문제 수정
- DTO 에서 기본타입을 래퍼타입으로 변경
- 커스텀 Getter 메소드를 추가하여, 객체안에 객체조회시 널체크 후 반환하도록 수정

close #128 