### PR TITLE
읽지않은 알림있는지 확인하는 API 추가

### DIFF
--- a/src/main/java/zip/ootd/ootdzip/notification/controller/NotificationController.java
+++ b/src/main/java/zip/ootd/ootdzip/notification/controller/NotificationController.java
@@ -55,4 +55,13 @@ public class NotificationController {
 
         return new ApiResponse<>(true);
     }
+
+    @Operation(summary = "읽지 않음 알림 존재 유무", description = "읽지 않은 알림이 있는지 확인합니다.")
+    @GetMapping(value = "/exist")
+    public ApiResponse<Boolean> getIsReadExist() {
+
+        Boolean response = notificationService.getIsReadExist(userService.getAuthenticatiedUser());
+
+        return new ApiResponse<>(response);
+    }
 }

--- a/src/main/java/zip/ootd/ootdzip/notification/repository/NotificationRepository.java
+++ b/src/main/java/zip/ootd/ootdzip/notification/repository/NotificationRepository.java
@@ -16,4 +16,7 @@ public interface NotificationRepository extends JpaRepository<Notification, Long
     Slice<Notification> findByUserIdAndIsRead(@Param("userId") Long userId,
             @Param("isRead") Boolean isRead,
             Pageable pageable);
+
+    @Query("SELECT count(n) from Notification n where n.receiver.id = :userId and n.isRead = :isRead")
+    Long findCountByUserIdAndIsRead(@Param("userId") Long userId, @Param("isRead") Boolean isRead);
 }

--- a/src/main/java/zip/ootd/ootdzip/notification/repository/NotificationRepository.java
+++ b/src/main/java/zip/ootd/ootdzip/notification/repository/NotificationRepository.java
@@ -18,5 +18,5 @@ public interface NotificationRepository extends JpaRepository<Notification, Long
             Pageable pageable);
 
     @Query("SELECT count(n) from Notification n where n.receiver.id = :userId and n.isRead = :isRead")
-    Long findCountByUserIdAndIsRead(@Param("userId") Long userId, @Param("isRead") Boolean isRead);
+    Long countByUserIdAndIsRead(@Param("userId") Long userId, @Param("isRead") Boolean isRead);
 }

--- a/src/main/java/zip/ootd/ootdzip/notification/service/NotificationService.java
+++ b/src/main/java/zip/ootd/ootdzip/notification/service/NotificationService.java
@@ -133,6 +133,11 @@ public class NotificationService {
         notification.readNotification();
     }
 
+    public Boolean getIsReadExist(User loginUser) {
+        Long isReadCount = notificationRepository.findCountByUserIdAndIsRead(loginUser.getId(), false);
+        return isReadCount > 0;
+    }
+
     private void checkValidUser(User loginUser, User target) {
         if (!loginUser.equals(target)) {
             throw new IllegalArgumentException("접근하려는 자원의 계정과 현재 로그인 계정이 일치하지 않습니다.");

--- a/src/main/java/zip/ootd/ootdzip/notification/service/NotificationService.java
+++ b/src/main/java/zip/ootd/ootdzip/notification/service/NotificationService.java
@@ -134,7 +134,7 @@ public class NotificationService {
     }
 
     public Boolean getIsReadExist(User loginUser) {
-        Long isReadCount = notificationRepository.findCountByUserIdAndIsRead(loginUser.getId(), false);
+        Long isReadCount = notificationRepository.countByUserIdAndIsRead(loginUser.getId(), false);
         return isReadCount > 0;
     }
 

--- a/src/test/java/zip/ootd/ootdzip/notification/repository/NotificationRepositoryTest.java
+++ b/src/test/java/zip/ootd/ootdzip/notification/repository/NotificationRepositoryTest.java
@@ -91,6 +91,30 @@ public class NotificationRepositoryTest extends IntegrationTestSupport {
                 .containsExactly(noti7.getId(), noti6.getId(), noti5.getId(), noti4.getId());
     }
 
+    @DisplayName("유저와 읽음처리에 해당하는 알림의 개수를 반환합니다.")
+    @Transactional
+    @Test
+    void findCountByUserIdAndIsRead() {
+        // given
+        User user = createUserBy("알람수신자");
+        User user1 = createUserBy("알람받는자");
+        Notification noti = createNotification(user, user1, NotificationType.OOTD_COMMENT, false);
+        Notification noti1 = createNotification(user, user1, NotificationType.TAG_COMMENT, false);
+        Notification noti2 = createNotification(user, user1, NotificationType.LIKE, false);
+        Notification noti3 = createNotification(user, user1, NotificationType.FOLLOW, false);
+        Notification noti4 = createNotification(user, user1, NotificationType.OOTD_COMMENT, true);
+        Notification noti5 = createNotification(user, user1, NotificationType.TAG_COMMENT, true);
+        Notification noti6 = createNotification(user, user1, NotificationType.LIKE, true);
+        Notification noti7 = createNotification(user, user1, NotificationType.FOLLOW, true);
+        Notification noti8 = createNotification(user1, user, NotificationType.OOTD_COMMENT, false);
+
+        // when
+        Long result = notificationRepository.findCountByUserIdAndIsRead(user.getId(), true);
+
+        // then
+        assertThat(result).isEqualTo(4L);
+    }
+
     private Notification createNotification(User receiver, User sender, NotificationType notificationType,
             Boolean isRead) {
 

--- a/src/test/java/zip/ootd/ootdzip/notification/repository/NotificationRepositoryTest.java
+++ b/src/test/java/zip/ootd/ootdzip/notification/repository/NotificationRepositoryTest.java
@@ -109,7 +109,7 @@ public class NotificationRepositoryTest extends IntegrationTestSupport {
         Notification noti8 = createNotification(user1, user, NotificationType.OOTD_COMMENT, false);
 
         // when
-        Long result = notificationRepository.findCountByUserIdAndIsRead(user.getId(), true);
+        Long result = notificationRepository.countByUserIdAndIsRead(user.getId(), true);
 
         // then
         assertThat(result).isEqualTo(4L);

--- a/src/test/java/zip/ootd/ootdzip/notification/service/NotificationServiceTest.java
+++ b/src/test/java/zip/ootd/ootdzip/notification/service/NotificationServiceTest.java
@@ -6,7 +6,6 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.data.domain.Sort;
-import org.springframework.transaction.annotation.Transactional;
 
 import zip.ootd.ootdzip.IntegrationTestSupport;
 import zip.ootd.ootdzip.common.response.CommonSliceResponse;
@@ -30,7 +29,6 @@ public class NotificationServiceTest extends IntegrationTestSupport {
     private NotificationRepository notificationRepository;
 
     @DisplayName("알람을 정상적으로 저장합니다.")
-    @Transactional
     @Test
     void saveNotification() {
         // given
@@ -49,7 +47,6 @@ public class NotificationServiceTest extends IntegrationTestSupport {
     }
 
     @DisplayName("읽지않은 알람을 정상적으로 가져옵니다.")
-    @Transactional
     @Test
     void getNotifications() {
         // given
@@ -84,7 +81,6 @@ public class NotificationServiceTest extends IntegrationTestSupport {
     }
 
     @DisplayName("읽은 알람을 정상적으로 가져옵니다.")
-    @Transactional
     @Test
     void getReadNotifications() {
         // given
@@ -119,7 +115,6 @@ public class NotificationServiceTest extends IntegrationTestSupport {
     }
 
     @DisplayName("알람을 정상적으로 읽음으로 수정 합니다.")
-    @Transactional
     @Test
     void updateIsRead() {
         // given
@@ -138,7 +133,6 @@ public class NotificationServiceTest extends IntegrationTestSupport {
     }
 
     @DisplayName("알람을 정상적으로 읽음/읽지 않음으로 수정시 다른사람이 수정시 예외가 발생합니다.")
-    @Transactional
     @Test
     void updateIsReadByOtherUser() {
         // given

--- a/src/test/java/zip/ootd/ootdzip/notification/service/NotificationServiceTest.java
+++ b/src/test/java/zip/ootd/ootdzip/notification/service/NotificationServiceTest.java
@@ -7,6 +7,8 @@ import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.data.domain.Sort;
 
+import org.springframework.transaction.annotation.Transactional;
+
 import zip.ootd.ootdzip.IntegrationTestSupport;
 import zip.ootd.ootdzip.common.response.CommonSliceResponse;
 import zip.ootd.ootdzip.notification.data.NotificationGetAllReq;
@@ -162,6 +164,28 @@ public class NotificationServiceTest extends IntegrationTestSupport {
                 .build();
 
         return notificationRepository.save(notification);
+    }
+
+    @DisplayName("읽지 않은 알람이 있을시 true, 아니면 false 를 반환합니다.")
+    @Test
+    void getIsReadExist() {
+        // given
+        User user = createUserBy("유저");
+        User user1 = createUserBy("유저1");
+        User user2 = createUserBy("유저2");
+        Notification noti = createNotification(user, user1, NotificationType.OOTD_COMMENT, false);
+        Notification noti1 = createNotification(user, user1, NotificationType.OOTD_COMMENT, true);
+        Notification noti2 = createNotification(user1, user, NotificationType.OOTD_COMMENT, true);
+        Notification noti3 = createNotification(user1, user, NotificationType.OOTD_COMMENT, true);
+        Notification noti4 = createNotification(user1, user, NotificationType.OOTD_COMMENT, false);
+
+        // when
+        Boolean result = notificationService.getIsReadExist(user);
+        Boolean result1 = notificationService.getIsReadExist(user2);
+
+        // then
+        assertThat(result).isEqualTo(true);
+        assertThat(result1).isEqualTo(false);
     }
 
     private User createUserBy(String userName) {


### PR DESCRIPTION
## 변경사항

- 읽지 않은 알림이 있는지 확인하는 기능 추가

## 참고사항

`notificationRepository` 에 기존에 있는 알람 조회 메서드로도 확인이 가능했지만(이는 객체 영속화과정이 필요합니다), 성능을 고려하여 Count 개수를 반환해주는 메서드를 추가했습니다. 

close #139 