### PR TITLE
fix : 유저 탈퇴관련 테스트 코드 실패하는 현상 수정

### DIFF
--- a/src/main/java/zip/ootd/ootdzip/brand/repository/BrandRepositoryImpl.java
+++ b/src/main/java/zip/ootd/ootdzip/brand/repository/BrandRepositoryImpl.java
@@ -2,6 +2,7 @@ package zip.ootd.ootdzip.brand.repository;
 
 import static zip.ootd.ootdzip.brand.domain.QBrand.*;
 import static zip.ootd.ootdzip.clothes.domain.QClothes.*;
+import static zip.ootd.ootdzip.user.domain.QUser.*;
 
 import java.util.List;
 
@@ -29,7 +30,9 @@ public class BrandRepositoryImpl extends QuerydslRepositorySupport implements Br
                 .distinct()
                 .from(clothes)
                 .innerJoin(clothes.brand, brand)
-                .where(clothes.user.id.eq(userId), eqIsPrivate(isPrivate))
+                .where(user.id.eq(userId),
+                        user.isDeleted.eq(false),
+                        eqIsPrivate(isPrivate))
                 .orderBy(brand.name.asc())
                 .fetch();
     }

--- a/src/test/java/zip/ootd/ootdzip/brand/service/BrandServiceTest.java
+++ b/src/test/java/zip/ootd/ootdzip/brand/service/BrandServiceTest.java
@@ -154,7 +154,7 @@ class BrandServiceTest extends IntegrationTestSupport {
         List<BrandDto> result = brandService.getUserBrands(user.getId(), user);
 
         //then
-          assertThat(result).hasSize(0);
+        assertThat(result).isEmpty();
     }
 
     private Clothes createClothesBy(User user, Brand brand, boolean isPrivate, String idx) {

--- a/src/test/java/zip/ootd/ootdzip/brand/service/BrandServiceTest.java
+++ b/src/test/java/zip/ootd/ootdzip/brand/service/BrandServiceTest.java
@@ -154,7 +154,7 @@ class BrandServiceTest extends IntegrationTestSupport {
         List<BrandDto> result = brandService.getUserBrands(user.getId(), user);
 
         //then
-        assertThat(result).hasSize(0);
+          assertThat(result).hasSize(0);
     }
 
     private Clothes createClothesBy(User user, Brand brand, boolean isPrivate, String idx) {

--- a/src/test/java/zip/ootd/ootdzip/ootd/repository/OotdRepositoryTest.java
+++ b/src/test/java/zip/ootd/ootdzip/ootd/repository/OotdRepositoryTest.java
@@ -354,7 +354,7 @@ public class OotdRepositoryTest extends IntegrationTestSupport {
         //then
         assertThat(ootds.getContent()).hasSize(10);
 
-        assertThat(ootds.getIsLast()).isTrue();
+        assertThat(ootds.getIsLast()).isFalse();
 
     }
 
@@ -380,7 +380,7 @@ public class OotdRepositoryTest extends IntegrationTestSupport {
         //then
         assertThat(ootds.getContent()).hasSize(10);
 
-        assertThat(ootds.getIsLast()).isTrue();
+        assertThat(ootds.getIsLast()).isFalse();
 
     }
 
@@ -406,7 +406,7 @@ public class OotdRepositoryTest extends IntegrationTestSupport {
         //then
         assertThat(ootds.getContent()).hasSize(5);
 
-        assertThat(ootds.getIsLast()).isFalse();
+        assertThat(ootds.getIsLast()).isTrue();
 
     }
 

--- a/src/test/java/zip/ootd/ootdzip/user/service/UserServiceTest.java
+++ b/src/test/java/zip/ootd/ootdzip/user/service/UserServiceTest.java
@@ -9,6 +9,7 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 
+import jakarta.persistence.EntityManager;
 import zip.ootd.ootdzip.IntegrationTestSupport;
 import zip.ootd.ootdzip.category.domain.Style;
 import zip.ootd.ootdzip.category.repository.StyleRepository;
@@ -45,6 +46,9 @@ class UserServiceTest extends IntegrationTestSupport {
 
     @Autowired
     private UserStyleRepository userStyleRepository;
+
+    @Autowired
+    private EntityManager em;
 
     @DisplayName("userId로 마이페이지에서 사용하는 유저 정보를 조회한다.")
     @Test
@@ -184,6 +188,8 @@ class UserServiceTest extends IntegrationTestSupport {
                 .build();
 
         userService.deleteUser(user1);
+        em.flush();
+        em.detach(user1);
         // when & then
         assertThatThrownBy(() -> userService.getUserInfoForMyPage(request, loginUser))
                 .isInstanceOf(CustomException.class)


### PR DESCRIPTION
## 변경 내용
- 브랜드 조회 시 삭제된 유저는 조회하지 않아야하지만 Where 어노테이션 조건이 걸리지 않아서 수정했습니다.
    - Where 어노테이션은 해당 엔티티를 직접 조회하거나 조인하는경우에 자동으로 붙지만 해당 쿼리에서는 user를 조인하지 않아서 조건절에 직접 명시했습니다.
- 마이페이지에서 유저를 조회하는 케이스는, 영속성에 1차 캐싱이 되어있어서 서비스 로직안에서 findById를 실행할 때 쿼리를 실행하지 않고 캐싱되어 있는 유저 엔티티를 가져오기 때문에 isDeleted가 true이지만 Exception이 발생하지 않아서 조회하는 서비스를 실행하기 전에 영속성을 flush 하여 해결하였습니다.


## 참고사항
- 인텔리제이에서 디버깅을 할 때 로드가 오래걸리는 현상은 Configuration 어노테이션이 붙은 곳에 중단점이 걸려있으면 로드가 오래걸립니다. (저도 알고싶지 않았습니다...)
https://velog.io/@joosing/improved-load-time-delay-in-intelliJ-debug-mode