### PR TITLE
유저 검색 전체개수 반환 추가

### DIFF
--- a/src/main/java/zip/ootd/ootdzip/user/controller/UserController.java
+++ b/src/main/java/zip/ootd/ootdzip/user/controller/UserController.java
@@ -27,7 +27,7 @@ import lombok.RequiredArgsConstructor;
 import zip.ootd.ootdzip.common.exception.CustomException;
 import zip.ootd.ootdzip.common.exception.code.ErrorCode;
 import zip.ootd.ootdzip.common.response.ApiResponse;
-import zip.ootd.ootdzip.common.response.CommonSliceResponse;
+import zip.ootd.ootdzip.common.response.CommonPageResponse;
 import zip.ootd.ootdzip.oauth.data.TokenInfo;
 import zip.ootd.ootdzip.user.controller.request.ProfileReq;
 import zip.ootd.ootdzip.user.controller.request.UserRegisterReq;
@@ -175,7 +175,7 @@ public class UserController {
 
     @Operation(summary = "유저 프로필 검색", description = "유저 프로필 검색 API")
     @GetMapping("/search")
-    public ApiResponse<CommonSliceResponse<UserSearchRes>> searchUser(UserSearchReq request) {
+    public ApiResponse<CommonPageResponse<UserSearchRes>> searchUser(UserSearchReq request) {
         return new ApiResponse<>(
                 userService.searchUser(request.toServiceRequest(), userService.getAuthenticatiedUser()));
     }

--- a/src/main/java/zip/ootd/ootdzip/user/repository/UserRepositoryCustom.java
+++ b/src/main/java/zip/ootd/ootdzip/user/repository/UserRepositoryCustom.java
@@ -1,14 +1,14 @@
 package zip.ootd.ootdzip.user.repository;
 
+import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
-import org.springframework.data.domain.Slice;
 
 import zip.ootd.ootdzip.user.domain.User;
 
 public interface UserRepositoryCustom {
-    Slice<User> searchUsers(String name, Pageable pageable);
+    Page<User> searchUsers(String name, Pageable pageable);
 
-    Slice<User> searchFollowers(String name, Long userId, Pageable pageable);
+    Page<User> searchFollowers(String name, Long userId, Pageable pageable);
 
-    Slice<User> searchFollowings(String name, Long userId, Pageable pageable);
+    Page<User> searchFollowings(String name, Long userId, Pageable pageable);
 }

--- a/src/main/java/zip/ootd/ootdzip/user/service/UserService.java
+++ b/src/main/java/zip/ootd/ootdzip/user/service/UserService.java
@@ -8,7 +8,7 @@ import java.util.Optional;
 import java.util.Set;
 
 import org.springframework.context.ApplicationEventPublisher;
-import org.springframework.data.domain.Slice;
+import org.springframework.data.domain.Page;
 import org.springframework.security.config.annotation.authentication.builders.AuthenticationManagerBuilder;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.context.SecurityContextHolder;
@@ -21,7 +21,7 @@ import zip.ootd.ootdzip.category.domain.Style;
 import zip.ootd.ootdzip.category.repository.StyleRepository;
 import zip.ootd.ootdzip.common.exception.CustomException;
 import zip.ootd.ootdzip.common.exception.code.ErrorCode;
-import zip.ootd.ootdzip.common.response.CommonSliceResponse;
+import zip.ootd.ootdzip.common.response.CommonPageResponse;
 import zip.ootd.ootdzip.notification.domain.NotificationType;
 import zip.ootd.ootdzip.notification.event.NotificationEvent;
 import zip.ootd.ootdzip.oauth.data.TokenInfo;
@@ -256,9 +256,9 @@ public class UserService {
         userRepository.save(loginUser);
     }
 
-    public CommonSliceResponse<UserSearchRes> searchUser(UserSearchSvcReq request, User loginUser) {
+    public CommonPageResponse<UserSearchRes> searchUser(UserSearchSvcReq request, User loginUser) {
 
-        Slice<User> findUsers = null;
+        Page<User> findUsers = null;
         UserSearchType userSearchType = request.getUserSearchType();
 
         if (userSearchType == UserSearchType.USER) {
@@ -280,7 +280,8 @@ public class UserService {
                 .map((item) -> UserSearchRes.of(item, loginUser))
                 .toList();
 
-        return new CommonSliceResponse<>(result, request.getPageable(), findUsers.isLast());
+        return new CommonPageResponse<>(result, request.getPageable(), findUsers.isLast(),
+                findUsers.getTotalElements());
     }
 
     public List<UserStyleRes> getUserStyle(User loginUser) {

--- a/src/test/java/zip/ootd/ootdzip/user/service/UserServiceTest.java
+++ b/src/test/java/zip/ootd/ootdzip/user/service/UserServiceTest.java
@@ -14,7 +14,7 @@ import zip.ootd.ootdzip.category.domain.Style;
 import zip.ootd.ootdzip.category.repository.StyleRepository;
 import zip.ootd.ootdzip.common.exception.CustomException;
 import zip.ootd.ootdzip.common.request.CommonPageRequest;
-import zip.ootd.ootdzip.common.response.CommonSliceResponse;
+import zip.ootd.ootdzip.common.response.CommonPageResponse;
 import zip.ootd.ootdzip.user.controller.response.ProfileRes;
 import zip.ootd.ootdzip.user.controller.response.UserInfoForMyPageRes;
 import zip.ootd.ootdzip.user.controller.response.UserSearchRes;
@@ -592,13 +592,14 @@ class UserServiceTest extends IntegrationTestSupport {
                 .build();
 
         // when
-        CommonSliceResponse<UserSearchRes> results = userService.searchUser(userSearchSvcReq, user3);
+        CommonPageResponse<UserSearchRes> results = userService.searchUser(userSearchSvcReq, user3);
 
         // then
         assertThat(results.getContent()).hasSize(2)
                 .extracting("id", "name")
                 .containsExactlyInAnyOrder(tuple(user1.getId(), user1.getName()),
                         tuple(user2.getId(), user2.getName()));
+        assertThat(results.getTotal()).isEqualTo(2);
     }
 
     @DisplayName("유저의 팔로잉을 기본 조회 한다.")
@@ -624,7 +625,7 @@ class UserServiceTest extends IntegrationTestSupport {
                 .build();
 
         // when
-        CommonSliceResponse<UserSearchRes> results = userService.searchUser(userSearchSvcReq, user3);
+        CommonPageResponse<UserSearchRes> results = userService.searchUser(userSearchSvcReq, user3);
 
         // then
         assertThat(results.getContent()).hasSize(3)
@@ -632,6 +633,7 @@ class UserServiceTest extends IntegrationTestSupport {
                 .containsExactlyInAnyOrder(tuple(user1.getId(), user1.getName()),
                         tuple(user2.getId(), user2.getName()),
                         tuple(user3.getId(), user3.getName()));
+        assertThat(results.getTotal()).isEqualTo(3);
     }
 
     @DisplayName("계정을 삭제한다.")


### PR DESCRIPTION
## 변경사항
- 유저 검색/팔로워/팔로잉 에서 검색된 전체 수를 반환하는 기능 추가

## 참고사항
QueryDSL 에서 `fetchCount()` 메서드를 사용하려했으나 deprecated 되어(복잡한 쿼리의 경우 제대로 작동되지않는다고함)서 직접 QueryDSL 카운트 쿼리를 작성했습니다.

close #168 