### PR TITLE
검색 시 count 일치하지 않는 현상 수정

### DIFF
--- a/src/main/java/zip/ootd/ootdzip/ootd/repository/OotdRepositoryImpl.java
+++ b/src/main/java/zip/ootd/ootdzip/ootd/repository/OotdRepositoryImpl.java
@@ -61,8 +61,7 @@ public class OotdRepositoryImpl extends QuerydslRepositorySupport implements Oot
                 .limit(pageSize + 1)
                 .fetch();
 
-        Long totalCount = queryFactory.select(ootd.count())
-                .distinct()
+        Long totalCount = queryFactory.select(ootd.countDistinct())
                 .from(ootd)
                 .innerJoin(ootd.styles, ootdStyle)
                 .innerJoin(ootd.ootdImages, ootdImage)

--- a/src/main/java/zip/ootd/ootdzip/ootd/repository/OotdRepositoryImpl.java
+++ b/src/main/java/zip/ootd/ootdzip/ootd/repository/OotdRepositoryImpl.java
@@ -62,6 +62,7 @@ public class OotdRepositoryImpl extends QuerydslRepositorySupport implements Oot
                 .fetch();
 
         Long totalCount = queryFactory.select(ootd.count())
+                .distinct()
                 .from(ootd)
                 .innerJoin(ootd.styles, ootdStyle)
                 .innerJoin(ootd.ootdImages, ootdImage)

--- a/src/test/java/zip/ootd/ootdzip/ootd/repository/OotdRepositoryTest.java
+++ b/src/test/java/zip/ootd/ootdzip/ootd/repository/OotdRepositoryTest.java
@@ -353,7 +353,7 @@ public class OotdRepositoryTest extends IntegrationTestSupport {
                 PageRequest.of(0, 10));
         //then
         assertThat(ootds.getContent()).hasSize(10);
-
+        assertThat(ootds.getTotal()).isEqualTo(28);
         assertThat(ootds.getIsLast()).isFalse();
 
     }
@@ -379,7 +379,7 @@ public class OotdRepositoryTest extends IntegrationTestSupport {
                 PageRequest.of(0, 10));
         //then
         assertThat(ootds.getContent()).hasSize(10);
-
+        assertThat(ootds.getTotal()).isEqualTo(28);
         assertThat(ootds.getIsLast()).isFalse();
 
     }
@@ -405,7 +405,7 @@ public class OotdRepositoryTest extends IntegrationTestSupport {
                 PageRequest.of(0, 10));
         //then
         assertThat(ootds.getContent()).hasSize(5);
-
+        assertThat(ootds.getTotal()).isEqualTo(5);
         assertThat(ootds.getIsLast()).isTrue();
 
     }


### PR DESCRIPTION
## 변경내용
- ootd 검색 시 1:N 구조로 인해서 결과를 distinct를 이용하여 중복제거하여 반환하였는데, 개수를 count할 때 중복제거를하지 않아서 개수가 일치하지 않는 현상 수정하였습니다.