### PR TITLE
fix: 인증되지 않은 요청에 적절한 ErrorResponse 반환하도록 수정

### DIFF
--- a/src/main/java/zip/ootd/ootdzip/common/config/SecurityConfig.java
+++ b/src/main/java/zip/ootd/ootdzip/common/config/SecurityConfig.java
@@ -13,6 +13,8 @@ import org.springframework.web.cors.CorsConfigurationSource;
 import org.springframework.web.cors.CorsUtils;
 
 import lombok.RequiredArgsConstructor;
+import zip.ootd.ootdzip.common.security.CustomAccessDeniedHandler;
+import zip.ootd.ootdzip.common.security.CustomAuthenticationEntryPoint;
 
 @Configuration
 @EnableWebSecurity
@@ -20,6 +22,8 @@ import lombok.RequiredArgsConstructor;
 public class SecurityConfig {
 
     private final CorsConfigurationSource corsConfigurationSource;
+    private final CustomAuthenticationEntryPoint authenticationEntryPoint;
+    private final CustomAccessDeniedHandler accessDeniedHandler;
 
     @Bean
     public SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception {
@@ -28,7 +32,9 @@ public class SecurityConfig {
                 .sessionManagement(session -> session.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
 
                 .oauth2ResourceServer(oauth2 -> oauth2
-                        .jwt(Customizer.withDefaults()))
+                        .jwt(Customizer.withDefaults())
+                        .authenticationEntryPoint(authenticationEntryPoint)
+                        .accessDeniedHandler(accessDeniedHandler))
                 .authorizeHttpRequests(auth -> auth
                         .requestMatchers(CorsUtils::isPreFlightRequest).permitAll() // Preflight 요청 허용
                         .requestMatchers(HttpMethod.POST, "/api/v1/oauth/token").permitAll()

--- a/src/main/java/zip/ootd/ootdzip/common/exception/code/ErrorCode.java
+++ b/src/main/java/zip/ootd/ootdzip/common/exception/code/ErrorCode.java
@@ -65,7 +65,7 @@ public enum ErrorCode {
 
     NONE_SOCIAL_ERROR(400, "U001", "존재 하지 않는 소셜로그인 요청"),
 
-    NOT_AUTHENTICATED_ERROR(400, "U002", "인가되지 않은 사용자"),
+    NOT_AUTHENTICATED_ERROR(401, "U002", "인증되지 않은 사용자"),
 
     DELETED_USER_ERROR(403, "U003", "탈퇴된 사용자"),
 

--- a/src/main/java/zip/ootd/ootdzip/common/security/CustomAccessDeniedHandler.java
+++ b/src/main/java/zip/ootd/ootdzip/common/security/CustomAccessDeniedHandler.java
@@ -1,0 +1,33 @@
+package zip.ootd.ootdzip.common.security;
+
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+
+import org.springframework.security.access.AccessDeniedException;
+import org.springframework.security.web.access.AccessDeniedHandler;
+import org.springframework.stereotype.Component;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+import zip.ootd.ootdzip.common.exception.code.ErrorCode;
+import zip.ootd.ootdzip.common.response.ErrorResponse;
+
+@Component
+@RequiredArgsConstructor
+public class CustomAccessDeniedHandler implements AccessDeniedHandler {
+
+    private final ObjectMapper objectMapper;
+
+    @Override
+    public void handle(HttpServletRequest request, HttpServletResponse response,
+            AccessDeniedException accessDeniedException) throws IOException {
+        ErrorCode error = ErrorCode.UNAUTHORIZED_USER_ERROR;
+        response.setCharacterEncoding(StandardCharsets.UTF_8.name());
+        response.setContentType("application/json");
+        response.setStatus(error.getStatus());
+        objectMapper.writeValue(response.getWriter(), ErrorResponse.of(error));
+    }
+}

--- a/src/main/java/zip/ootd/ootdzip/common/security/CustomAuthenticationEntryPoint.java
+++ b/src/main/java/zip/ootd/ootdzip/common/security/CustomAuthenticationEntryPoint.java
@@ -1,0 +1,33 @@
+package zip.ootd.ootdzip.common.security;
+
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+
+import org.springframework.security.core.AuthenticationException;
+import org.springframework.security.web.AuthenticationEntryPoint;
+import org.springframework.stereotype.Component;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+import zip.ootd.ootdzip.common.exception.code.ErrorCode;
+import zip.ootd.ootdzip.common.response.ErrorResponse;
+
+@Component
+@RequiredArgsConstructor
+public class CustomAuthenticationEntryPoint implements AuthenticationEntryPoint {
+
+    private final ObjectMapper objectMapper;
+
+    @Override
+    public void commence(HttpServletRequest request, HttpServletResponse response,
+            AuthenticationException authException) throws IOException {
+        ErrorCode error = ErrorCode.NOT_AUTHENTICATED_ERROR;
+        response.setCharacterEncoding(StandardCharsets.UTF_8.name());
+        response.setContentType("application/json");
+        response.setStatus(error.getStatus());
+        objectMapper.writeValue(response.getWriter(), ErrorResponse.of(error));
+    }
+}


### PR DESCRIPTION
미인증 요청(잘못된 액세스 토큰 등)에 `ErrorCode.NOT_AUTHENTICATED_ERROR`에 해당하는 Status=401, divisionCode: U002를 반환합니다.