### PR TITLE
fix: 잘못된 액세스 토큰으로 요청했을 경우 ErrorResponse 반환

### DIFF
--- a/src/main/java/zip/ootd/ootdzip/common/exception/GlobalExceptionHandler.java
+++ b/src/main/java/zip/ootd/ootdzip/common/exception/GlobalExceptionHandler.java
@@ -6,6 +6,7 @@ import java.util.NoSuchElementException;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.http.converter.HttpMessageNotReadableException;
+import org.springframework.security.oauth2.server.resource.InvalidBearerTokenException;
 import org.springframework.web.bind.MethodArgumentNotValidException;
 import org.springframework.web.bind.MissingRequestHeaderException;
 import org.springframework.web.bind.MissingServletRequestParameterException;
@@ -184,10 +185,23 @@ public class GlobalExceptionHandler {
         return new ResponseEntity<>(response, HttpStatus.INTERNAL_SERVER_ERROR);
     }
 
+    /**
+     * Bearer 토큰이 잘못되었을 경우
+     * @param ex InvalidBearerTokenException
+     * @return ResponseEntity<ErrorResponse>
+     */
+    @ExceptionHandler(InvalidBearerTokenException.class)
+    protected final ResponseEntity<ErrorResponse> handleInvalidBearerTokenException(InvalidBearerTokenException ex) {
+        log.debug(InvalidBearerTokenException.class.getSimpleName(), ex);
+        final ErrorResponse response = ErrorResponse.of(ErrorCode.NOT_AUTHENTICATED_ERROR, ex.getMessage());
+        return new ResponseEntity<>(response, HttpStatus.UNAUTHORIZED);
+    }
+
     // ======================================Custom Exception===========================================================
 
     @ExceptionHandler(CustomException.class)
     protected final ResponseEntity<ErrorResponse> handleAllExceptions(CustomException ex) {
+
         log.error("Custom Exception", ex);
 
         return new ResponseEntity<>(ErrorResponse.of(ex.getErrorCode(), ex.getMessage()),


### PR DESCRIPTION
엑세스 토큰이 만료 등으로 Jwt 오류가 발생할 경우 InvalidBearerTokenException이 발생하여 핸들러에 추가하고 동일한 에러 응답을 반환합니다.