### PR TITLE
dev 로그인 시 redirect_uri 전달 기능 추가

### DIFF
--- a/src/main/java/zip/ootd/ootdzip/common/config/AuthorizationConfig.java
+++ b/src/main/java/zip/ootd/ootdzip/common/config/AuthorizationConfig.java
@@ -13,6 +13,7 @@ import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.oauth2.client.registration.ClientRegistration;
 import org.springframework.security.oauth2.client.registration.ClientRegistrationRepository;
 import org.springframework.security.oauth2.client.web.AuthorizationRequestRepository;
+import org.springframework.security.oauth2.client.web.OAuth2AuthorizationRequestResolver;
 import org.springframework.security.oauth2.core.endpoint.OAuth2AuthorizationRequest;
 import org.springframework.security.web.SecurityFilterChain;
 import org.springframework.web.cors.CorsConfigurationSource;
@@ -21,6 +22,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 
 import lombok.RequiredArgsConstructor;
 import zip.ootd.ootdzip.oauth.OAuth2AuthenticationSuccessHandler;
+import zip.ootd.ootdzip.oauth.RedirectUriParameterOAuth2AuthorizationRequestResolver;
 import zip.ootd.ootdzip.oauth.provider.ClientSecretGenerator;
 import zip.ootd.ootdzip.oauth.repository.InMemoryDynamicClientRegistrationRepository;
 import zip.ootd.ootdzip.oauth.repository.InMemoryOAuth2AuthorizationRequestRepository;
@@ -34,6 +36,9 @@ public class AuthorizationConfig {
 
     private static final String redirectionUri = "/api/v1/login/oauth/code/*";
 
+    private static final List<String> redirectUriParameterAllowedRegistrationIds = List.of("dev");
+
+    private final OAuth2ClientProperties clientProperties;
     private final CorsConfigurationSource corsConfigurationSource;
     private final TokenService tokenService;
     private final ObjectMapper objectMapper;
@@ -47,6 +52,8 @@ public class AuthorizationConfig {
                 .oauth2Login(oauth2Login -> oauth2Login
                         .authorizationEndpoint(authorization -> authorization
                                 .baseUri(authorizationUri)
+                                .authorizationRequestResolver(oauth2AuthorizationRequestResolver(
+                                        clientRegistrationRepository(clientProperties)))
                                 .authorizationRequestRepository(authorizationRequestRepository()))
                         .redirectionEndpoint(redirection -> redirection
                                 .baseUri(redirectionUri))
@@ -59,6 +66,13 @@ public class AuthorizationConfig {
     @Bean
     public OAuth2AuthenticationSuccessHandler successHandler(TokenService tokenService, ObjectMapper objectMapper) {
         return new OAuth2AuthenticationSuccessHandler(tokenService, objectMapper);
+    }
+
+    @Bean
+    public OAuth2AuthorizationRequestResolver oauth2AuthorizationRequestResolver(
+            ClientRegistrationRepository clientRegistrationRepository) {
+        return new RedirectUriParameterOAuth2AuthorizationRequestResolver(clientRegistrationRepository,
+                authorizationUri, redirectUriParameterAllowedRegistrationIds);
     }
 
     @Bean

--- a/src/main/java/zip/ootd/ootdzip/oauth/OAuth2AuthenticationSuccessHandler.java
+++ b/src/main/java/zip/ootd/ootdzip/oauth/OAuth2AuthenticationSuccessHandler.java
@@ -10,7 +10,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;
-import zip.ootd.ootdzip.oauth.data.RegisteredOAuth2User;
+import zip.ootd.ootdzip.oauth.data.AuthorizedUser;
 import zip.ootd.ootdzip.oauth.data.TokenResponse;
 import zip.ootd.ootdzip.oauth.service.TokenService;
 
@@ -23,7 +23,7 @@ public class OAuth2AuthenticationSuccessHandler implements AuthenticationSuccess
     @Override
     public void onAuthenticationSuccess(HttpServletRequest request, HttpServletResponse response,
             Authentication authentication) throws IOException {
-        RegisteredOAuth2User principal = (RegisteredOAuth2User)authentication.getPrincipal();
+        AuthorizedUser principal = (AuthorizedUser)authentication.getPrincipal();
         TokenResponse tokenResponse = tokenService.issueNewAccessToken(principal.getUser());
 
         response.setContentType("application/json");

--- a/src/main/java/zip/ootd/ootdzip/oauth/RedirectUriParameterOAuth2AuthorizationRequestResolver.java
+++ b/src/main/java/zip/ootd/ootdzip/oauth/RedirectUriParameterOAuth2AuthorizationRequestResolver.java
@@ -1,0 +1,66 @@
+package zip.ootd.ootdzip.oauth;
+
+import java.util.List;
+import java.util.Set;
+
+import org.springframework.security.oauth2.client.registration.ClientRegistrationRepository;
+import org.springframework.security.oauth2.client.web.DefaultOAuth2AuthorizationRequestResolver;
+import org.springframework.security.oauth2.client.web.OAuth2AuthorizationRequestResolver;
+import org.springframework.security.oauth2.core.endpoint.OAuth2AuthorizationRequest;
+
+import io.jsonwebtoken.lang.Assert;
+import jakarta.servlet.http.HttpServletRequest;
+
+public class RedirectUriParameterOAuth2AuthorizationRequestResolver implements OAuth2AuthorizationRequestResolver {
+
+    private static final String REDIRECT_URI_PARAMETER_NAME = "redirect_uri";
+
+    private static final String REGISTRATION_ID_ATTRIBUTE_NAME = "registration_id";
+
+    private final DefaultOAuth2AuthorizationRequestResolver delegate;
+    private final Set<String> allowedRegistrationIds;
+
+    public RedirectUriParameterOAuth2AuthorizationRequestResolver(
+            ClientRegistrationRepository clientRegistrationRepository,
+            String authorizationRequestBaseUri,
+            List<String> allowedRegistrationIds) {
+        Assert.notNull(allowedRegistrationIds, "allowedRegistrationIds cannot be null");
+        this.delegate = new DefaultOAuth2AuthorizationRequestResolver(clientRegistrationRepository,
+                authorizationRequestBaseUri);
+        this.allowedRegistrationIds = Set.copyOf(allowedRegistrationIds);
+    }
+
+    @Override
+    public OAuth2AuthorizationRequest resolve(HttpServletRequest request) {
+        OAuth2AuthorizationRequest authorizationRequest = delegate.resolve(request);
+        return resolveRedirectUri(authorizationRequest, request);
+    }
+
+    @Override
+    public OAuth2AuthorizationRequest resolve(HttpServletRequest request, String clientRegistrationId) {
+        OAuth2AuthorizationRequest authorizationRequest = delegate.resolve(request, clientRegistrationId);
+        return resolveRedirectUri(authorizationRequest, request);
+    }
+
+    private OAuth2AuthorizationRequest resolveRedirectUri(OAuth2AuthorizationRequest authorizationRequest,
+            HttpServletRequest request) {
+        if (authorizationRequest == null) {
+            return null;
+        }
+        String registrationId = authorizationRequest.getAttribute(REGISTRATION_ID_ATTRIBUTE_NAME);
+        if (allowedRegistrationIds.contains(registrationId)) {
+            String redirectUri = request.getParameter(REDIRECT_URI_PARAMETER_NAME);
+            if (redirectUri != null) {
+                return withRedirectUri(authorizationRequest, redirectUri);
+            }
+        }
+        return authorizationRequest;
+    }
+
+    private OAuth2AuthorizationRequest withRedirectUri(OAuth2AuthorizationRequest authorizationRequest,
+            String redirectUri) {
+        return OAuth2AuthorizationRequest.from(authorizationRequest)
+                .redirectUri(redirectUri)
+                .build();
+    }
+}

--- a/src/main/java/zip/ootd/ootdzip/oauth/controller/TokenController.java
+++ b/src/main/java/zip/ootd/ootdzip/oauth/controller/TokenController.java
@@ -4,6 +4,7 @@ import org.apache.commons.lang3.NotImplementedException;
 import org.springframework.http.MediaType;
 import org.springframework.security.oauth2.core.endpoint.OAuth2ParameterNames;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
@@ -25,18 +26,21 @@ public class TokenController {
     private final TokenService tokenService;
 
     // Swagger 문서용 더미 메소드, 실제로는 AuthoriationConfig에서 처리.
-    @Operation(summary = "소셜 로그인", description = "해당 경로에 접속하여 로그인 과정 시작", responses = {
-            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "302")
-    })
+    @Operation(summary = "소셜 로그인",
+            description = "해당 경로에 접속하여 로그인 과정 시작, provider=dev일 경우 redirect_uri 전달 가능",
+            responses = {
+                    @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "302")
+            })
     @GetMapping("/api/v1/login/authorization/{provider}")
-    public void login() {
+    public void login(@PathVariable("provider") String provider, @RequestParam("redirect_uri") String redirectUri) {
         throw new NotImplementedException();
     }
 
     // Swagger 문서용 더미 메소드, 실제로는 AuthoriationConfig에서 처리.
     @Operation(summary = "코드로 토큰 변환", description = "로그인 요청에서 callback 경로로 전달된 query params를 전달하여 토큰 발급")
     @GetMapping("/api/v1/login/oauth/code/{provider}")
-    public TokenResponse code(@RequestParam("code") String code, @RequestParam("state") String state) {
+    public TokenResponse code(@PathVariable("provider") String provider, @RequestParam("code") String code,
+            @RequestParam("state") String state) {
         throw new NotImplementedException();
     }
 

--- a/src/main/java/zip/ootd/ootdzip/oauth/data/AuthorizedUser.java
+++ b/src/main/java/zip/ootd/ootdzip/oauth/data/AuthorizedUser.java
@@ -12,6 +12,9 @@ import java.util.TreeSet;
 
 import org.springframework.security.core.GrantedAuthority;
 import org.springframework.security.core.authority.AuthorityUtils;
+import org.springframework.security.oauth2.core.oidc.OidcIdToken;
+import org.springframework.security.oauth2.core.oidc.OidcUserInfo;
+import org.springframework.security.oauth2.core.oidc.user.OidcUser;
 import org.springframework.security.oauth2.core.user.OAuth2User;
 
 import lombok.EqualsAndHashCode;
@@ -22,7 +25,7 @@ import zip.ootd.ootdzip.user.domain.User;
 @Getter
 @EqualsAndHashCode
 @ToString
-public class AuthorizedUser implements OAuth2User {
+public class AuthorizedUser implements OAuth2User, OidcUser {
 
     private final Set<GrantedAuthority> authorities;
 
@@ -48,5 +51,20 @@ public class AuthorizedUser implements OAuth2User {
                 Comparator.comparing(GrantedAuthority::getAuthority));
         sortedAuthorities.addAll(authorities);
         return sortedAuthorities;
+    }
+
+    @Override
+    public Map<String, Object> getClaims() {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public OidcUserInfo getUserInfo() {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public OidcIdToken getIdToken() {
+        throw new UnsupportedOperationException();
     }
 }

--- a/src/main/java/zip/ootd/ootdzip/oauth/data/AuthorizedUser.java
+++ b/src/main/java/zip/ootd/ootdzip/oauth/data/AuthorizedUser.java
@@ -22,7 +22,7 @@ import zip.ootd.ootdzip.user.domain.User;
 @Getter
 @EqualsAndHashCode
 @ToString
-public class RegisteredOAuth2User implements OAuth2User {
+public class AuthorizedUser implements OAuth2User {
 
     private final Set<GrantedAuthority> authorities;
 
@@ -30,7 +30,7 @@ public class RegisteredOAuth2User implements OAuth2User {
 
     private final User user;
 
-    public RegisteredOAuth2User(Collection<? extends GrantedAuthority> authorities, Map<String, Object> attributes,
+    public AuthorizedUser(Collection<? extends GrantedAuthority> authorities, Map<String, Object> attributes,
             User user) {
         this.authorities = authorities != null
                 ? Collections.unmodifiableSet(new LinkedHashSet<>(this.sortAuthorities(authorities)))

--- a/src/main/java/zip/ootd/ootdzip/oauth/service/AuthorizedOAuth2UserService.java
+++ b/src/main/java/zip/ootd/ootdzip/oauth/service/AuthorizedOAuth2UserService.java
@@ -36,14 +36,14 @@ public class AuthorizedOAuth2UserService implements OAuth2UserService<OAuth2User
     private static <T> T getNestedValue(Map<String, Object> map, String[] keys) {
         Map<String, Object> cur = map;
         for (String key : keys) {
-            Object o = cur.get(key);
-            if (o == null) {
+            Object obj = cur.get(key);
+            if (obj == null) {
                 return null;
             }
-            if (o instanceof Map) {
-                cur = (Map<String, Object>)o;
+            if (obj instanceof Map) {
+                cur = (Map<String, Object>)obj;
             } else {
-                return (T)o;
+                return (T)obj;
             }
         }
         return null;

--- a/src/main/java/zip/ootd/ootdzip/oauth/service/AuthorizedOAuth2UserService.java
+++ b/src/main/java/zip/ootd/ootdzip/oauth/service/AuthorizedOAuth2UserService.java
@@ -25,13 +25,13 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import lombok.RequiredArgsConstructor;
 import zip.ootd.ootdzip.common.exception.CustomException;
 import zip.ootd.ootdzip.common.exception.code.ErrorCode;
-import zip.ootd.ootdzip.oauth.data.RegisteredOAuth2User;
+import zip.ootd.ootdzip.oauth.data.AuthorizedUser;
 import zip.ootd.ootdzip.user.domain.User;
 import zip.ootd.ootdzip.user.repository.UserRepository;
 
 @Service
 @RequiredArgsConstructor
-public class RegisteredOAuth2UserService implements OAuth2UserService<OAuth2UserRequest, OAuth2User> {
+public class AuthorizedOAuth2UserService implements OAuth2UserService<OAuth2UserRequest, OAuth2User> {
 
     private static final String ID_TOKEN = "id_token";
 
@@ -78,7 +78,7 @@ public class RegisteredOAuth2UserService implements OAuth2UserService<OAuth2User
             throw new CustomException(ErrorCode.DELETED_USER_ERROR);
         }
 
-        return new RegisteredOAuth2User(authorities, attributes, serviceUser);
+        return new AuthorizedUser(authorities, attributes, serviceUser);
     }
 
     private User findOrCreateUser(String provider, String providerId) {

--- a/src/main/java/zip/ootd/ootdzip/oauth/service/AuthorizedOAuth2UserService.java
+++ b/src/main/java/zip/ootd/ootdzip/oauth/service/AuthorizedOAuth2UserService.java
@@ -1,109 +1,65 @@
 package zip.ootd.ootdzip.oauth.service;
 
-import java.nio.charset.Charset;
-import java.nio.charset.StandardCharsets;
-import java.util.Base64;
-import java.util.Collection;
 import java.util.Map;
-import java.util.Optional;
-import java.util.Set;
 
-import org.springframework.security.core.GrantedAuthority;
-import org.springframework.security.oauth2.client.userinfo.DefaultOAuth2UserService;
 import org.springframework.security.oauth2.client.userinfo.OAuth2UserRequest;
 import org.springframework.security.oauth2.client.userinfo.OAuth2UserService;
 import org.springframework.security.oauth2.core.OAuth2AuthenticationException;
 import org.springframework.security.oauth2.core.user.OAuth2User;
-import org.springframework.security.oauth2.core.user.OAuth2UserAuthority;
-import org.springframework.security.oauth2.jwt.JwtClaimNames;
 import org.springframework.stereotype.Service;
 
-import com.fasterxml.jackson.core.JsonProcessingException;
-import com.fasterxml.jackson.core.type.TypeReference;
-import com.fasterxml.jackson.databind.ObjectMapper;
-
-import lombok.RequiredArgsConstructor;
-import zip.ootd.ootdzip.common.exception.CustomException;
-import zip.ootd.ootdzip.common.exception.code.ErrorCode;
-import zip.ootd.ootdzip.oauth.data.AuthorizedUser;
-import zip.ootd.ootdzip.user.domain.User;
-import zip.ootd.ootdzip.user.repository.UserRepository;
-
 @Service
-@RequiredArgsConstructor
 public class AuthorizedOAuth2UserService implements OAuth2UserService<OAuth2UserRequest, OAuth2User> {
 
-    private static final String ID_TOKEN = "id_token";
+    private static final String ATTRIBUTE_DELIMITER = "/";
 
-    private final UserRepository userRepository;
-    private final UserSocialLoginService userSocialLoginService;
+    private final AuthorizedUserService authorizedUserService;
 
-    private final DefaultOAuth2UserService delegate = new DefaultOAuth2UserService();
+    private final CustomOAuth2UserService delegate;
+
+    public AuthorizedOAuth2UserService(AuthorizedUserService authorizedUserService) {
+        this.authorizedUserService = authorizedUserService;
+        this.delegate = new CustomOAuth2UserService();
+
+        this.delegate.setAttributesConverter((request) -> (attributes) -> {
+            String userNameAttributeName = getUserNameAttributeName(request);
+            // naver 로그인 시 "response" -> "id" 경로에 저장된 사용자 id를 "response/id"를 키로 저장
+            if (userNameAttributeName.contains(ATTRIBUTE_DELIMITER)) {
+                String[] keys = userNameAttributeName.split(ATTRIBUTE_DELIMITER);
+                String userName = getNestedValue(attributes, keys);
+                attributes.put(userNameAttributeName, userName);
+            }
+            return attributes;
+        });
+    }
+
+    private static <T> T getNestedValue(Map<String, Object> map, String[] keys) {
+        Map<String, Object> cur = map;
+        for (String key : keys) {
+            Object o = cur.get(key);
+            if (o == null) {
+                return null;
+            }
+            if (o instanceof Map) {
+                cur = (Map<String, Object>)o;
+            } else {
+                return (T)o;
+            }
+        }
+        return null;
+    }
 
     @Override
     public OAuth2User loadUser(OAuth2UserRequest userRequest) throws OAuth2AuthenticationException {
-        User serviceUser;
-        Map<String, Object> attributes;
-        Collection<? extends GrantedAuthority> authorities;
+        OAuth2User oauth2User = delegate.loadUser(userRequest);
 
-        String registrationId = userRequest.getClientRegistration().getRegistrationId();
-        if ("apple".equals(registrationId)) {
-            // Apple ID일 경우 id_token에서 sub 추출
-            String idToken = userRequest.getAdditionalParameters().get(ID_TOKEN).toString();
-            Map<String, Object> claims = parseClaims(idToken);
-            String providerUserId = (String)claims.get(JwtClaimNames.SUB);
-
-            serviceUser = findOrCreateUser(registrationId, providerUserId);
-            attributes = Map.of(JwtClaimNames.SUB, providerUserId);
-            authorities = Set.of(new OAuth2UserAuthority(attributes));
-        } else {
-            // 토큰 정보 API에서 사용자 정보 받아오기
-            OAuth2User oauth2User = delegate.loadUser(userRequest);
-            // 받아온 정보의 sub로 필요 시 DB에 저장하고 user 가져오기
-            String providerUserId;
-            if ("naver".equals(registrationId)) {
-                // Spring Security 6.3.0-M2부터 nested user-name-attribute 설정 가능
-                // https://github.com/spring-projects/spring-security/pull/14265
-                providerUserId = (String)((Map<String, Object>)oauth2User.getAttributes().get("response")).get("id");
-            } else {
-                providerUserId = oauth2User.getName();
-            }
-            serviceUser = findOrCreateUser(registrationId, providerUserId);
-            attributes = oauth2User.getAttributes();
-            authorities = oauth2User.getAuthorities();
-        }
-
-        // 탈퇴한 유저가 소셜 로그인을 시도할 경우 에러
-        if (serviceUser.getIsDeleted()) {
-            throw new CustomException(ErrorCode.DELETED_USER_ERROR);
-        }
-
-        return new AuthorizedUser(authorities, attributes, serviceUser);
+        return authorizedUserService.getAuthorizedUser(userRequest, oauth2User);
     }
 
-    private User findOrCreateUser(String provider, String providerId) {
-        Optional<User> optionalUser = userSocialLoginService.findUser(provider, providerId);
-        if (optionalUser.isPresent()) {
-            return optionalUser.get();
-        }
-
-        User user = User.getDefault();
-        user = userRepository.save(user);
-        userSocialLoginService.addUserSocialLogin(provider, providerId, user);
-
-        return user;
-    }
-
-    private Map<String, Object> parseClaims(String jwt) {
-        // JwtParser를 사용하면 alg, exp 검사 과정이 포함되기 때문에 단순히 payload만 변환
-        Charset chs = StandardCharsets.UTF_8;
-        String[] parts = jwt.split("\\.");
-        String payload = new String(Base64.getUrlDecoder().decode(parts[1].getBytes(chs)), chs);
-        try {
-            return new ObjectMapper().readValue(payload, new TypeReference<>() {
-            });
-        } catch (JsonProcessingException e) {
-            throw new RuntimeException(e);
-        }
+    private String getUserNameAttributeName(OAuth2UserRequest userRequest) {
+        return userRequest.getClientRegistration()
+                .getProviderDetails()
+                .getUserInfoEndpoint()
+                .getUserNameAttributeName();
     }
 }

--- a/src/main/java/zip/ootd/ootdzip/oauth/service/AuthorizedOidcUserService.java
+++ b/src/main/java/zip/ootd/ootdzip/oauth/service/AuthorizedOidcUserService.java
@@ -1,0 +1,27 @@
+package zip.ootd.ootdzip.oauth.service;
+
+import org.springframework.security.oauth2.client.oidc.userinfo.OidcUserRequest;
+import org.springframework.security.oauth2.client.oidc.userinfo.OidcUserService;
+import org.springframework.security.oauth2.client.userinfo.OAuth2UserService;
+import org.springframework.security.oauth2.core.OAuth2AuthenticationException;
+import org.springframework.security.oauth2.core.oidc.user.OidcUser;
+import org.springframework.stereotype.Service;
+
+import lombok.RequiredArgsConstructor;
+import zip.ootd.ootdzip.oauth.data.AuthorizedUser;
+
+@Service
+@RequiredArgsConstructor
+public class AuthorizedOidcUserService implements OAuth2UserService<OidcUserRequest, OidcUser> {
+
+    private final AuthorizedUserService authorizedUserService;
+
+    private final OidcUserService delegate = new OidcUserService();
+
+    @Override
+    public AuthorizedUser loadUser(OidcUserRequest userRequest) throws OAuth2AuthenticationException {
+        OidcUser oidcUser = delegate.loadUser(userRequest);
+
+        return authorizedUserService.getAuthorizedUser(userRequest, oidcUser);
+    }
+}

--- a/src/main/java/zip/ootd/ootdzip/oauth/service/AuthorizedUserService.java
+++ b/src/main/java/zip/ootd/ootdzip/oauth/service/AuthorizedUserService.java
@@ -1,0 +1,38 @@
+package zip.ootd.ootdzip.oauth.service;
+
+import java.util.Optional;
+
+import org.springframework.security.oauth2.client.userinfo.OAuth2UserRequest;
+import org.springframework.security.oauth2.core.user.OAuth2User;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import lombok.RequiredArgsConstructor;
+import zip.ootd.ootdzip.oauth.data.AuthorizedUser;
+import zip.ootd.ootdzip.user.domain.User;
+import zip.ootd.ootdzip.user.repository.UserRepository;
+
+@Service
+@RequiredArgsConstructor
+public class AuthorizedUserService {
+
+    private final UserRepository userRepository;
+    private final UserSocialLoginService userSocialLoginService;
+
+    @Transactional
+    public AuthorizedUser getAuthorizedUser(OAuth2UserRequest userRequest, OAuth2User oauth2User) {
+        String registrationId = userRequest.getClientRegistration().getRegistrationId();
+        String oauth2UserName = oauth2User.getName();
+
+        Optional<User> foundUser = userSocialLoginService.findUser(registrationId, oauth2UserName);
+        User user = foundUser.orElseGet(() -> {
+            // 신규 유저 생성
+            User newUser = User.getDefault();
+            newUser = userRepository.save(newUser);
+            userSocialLoginService.addUserSocialLogin(registrationId, oauth2UserName, newUser);
+            return newUser;
+        });
+
+        return new AuthorizedUser(oauth2User.getAuthorities(), oauth2User.getAttributes(), user);
+    }
+}

--- a/src/main/java/zip/ootd/ootdzip/oauth/service/CustomOAuth2UserService.java
+++ b/src/main/java/zip/ootd/ootdzip/oauth/service/CustomOAuth2UserService.java
@@ -1,0 +1,213 @@
+package zip.ootd.ootdzip.oauth.service;
+
+import java.util.Collection;
+import java.util.LinkedHashSet;
+import java.util.Map;
+
+import org.springframework.core.ParameterizedTypeReference;
+import org.springframework.core.convert.converter.Converter;
+import org.springframework.http.RequestEntity;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.oauth2.client.http.OAuth2ErrorResponseErrorHandler;
+import org.springframework.security.oauth2.client.userinfo.OAuth2UserRequest;
+import org.springframework.security.oauth2.client.userinfo.OAuth2UserRequestEntityConverter;
+import org.springframework.security.oauth2.client.userinfo.OAuth2UserService;
+import org.springframework.security.oauth2.core.OAuth2AccessToken;
+import org.springframework.security.oauth2.core.OAuth2AuthenticationException;
+import org.springframework.security.oauth2.core.OAuth2AuthorizationException;
+import org.springframework.security.oauth2.core.OAuth2Error;
+import org.springframework.security.oauth2.core.user.DefaultOAuth2User;
+import org.springframework.security.oauth2.core.user.OAuth2User;
+import org.springframework.security.oauth2.core.user.OAuth2UserAuthority;
+import org.springframework.util.Assert;
+import org.springframework.util.StringUtils;
+import org.springframework.web.client.ResponseErrorHandler;
+import org.springframework.web.client.RestClientException;
+import org.springframework.web.client.RestOperations;
+import org.springframework.web.client.RestTemplate;
+import org.springframework.web.client.UnknownContentTypeException;
+
+/**
+ * Source: <a href="https://github.com/ahmd-nabil/spring-security/blob/e3b5da62ef7322ab5bdb535fa306313db19f5a25/oauth2/oauth2-client/src/main/java/org/springframework/security/oauth2/client/userinfo/DefaultOAuth2UserService.java">DefaultOAuth2UserService.java</a>
+ * <p>
+ * An implementation of an {@link OAuth2UserService} that supports standard OAuth 2.0
+ * Provider's.
+ * <p>
+ * For standard OAuth 2.0 Provider's, the attribute name used to access the user's name
+ * from the UserInfo response is required and therefore must be available via
+ * {@link ClientRegistration.ProviderDetails.UserInfoEndpoint#getUserNameAttributeName()
+ * UserInfoEndpoint.getUserNameAttributeName()}.
+ * <p>
+ * <b>NOTE:</b> Attribute names are <b>not</b> standardized between providers and
+ * therefore will vary. Please consult the provider's API documentation for the set of
+ * supported user attribute names.
+ * @author Joe Grandja
+ * @see OAuth2UserService
+ * @see OAuth2UserRequest
+ * @see OAuth2User
+ * @see DefaultOAuth2User
+ * @since 5.0
+ */
+public class CustomOAuth2UserService implements OAuth2UserService<OAuth2UserRequest, OAuth2User> {
+
+    private static final String MISSING_USER_INFO_URI_ERROR_CODE = "missing_user_info_uri";
+
+    private static final String MISSING_USER_NAME_ATTRIBUTE_ERROR_CODE = "missing_user_name_attribute";
+
+    private static final String INVALID_USER_INFO_RESPONSE_ERROR_CODE = "invalid_user_info_response";
+
+    private static final ParameterizedTypeReference<Map<String, Object>> PARAMETERIZED_RESPONSE_TYPE = new ParameterizedTypeReference<Map<String, Object>>() {
+    };
+
+    private Converter<OAuth2UserRequest, RequestEntity<?>> requestEntityConverter = new OAuth2UserRequestEntityConverter();
+
+    private Converter<OAuth2UserRequest, Converter<Map<String, Object>, Map<String, Object>>> attributesConverter = (
+            request) -> (attributes) -> attributes;
+
+    private RestOperations restOperations;
+
+    public CustomOAuth2UserService() {
+        RestTemplate restTemplate = new RestTemplate();
+        restTemplate.setErrorHandler(new OAuth2ErrorResponseErrorHandler());
+        this.restOperations = restTemplate;
+    }
+
+    @Override
+    public OAuth2User loadUser(OAuth2UserRequest userRequest) throws OAuth2AuthenticationException {
+        Assert.notNull(userRequest, "userRequest cannot be null");
+        String userNameAttributeName = getUserNameAttributeName(userRequest);
+        RequestEntity<?> request = this.requestEntityConverter.convert(userRequest);
+        ResponseEntity<Map<String, Object>> response = getResponse(userRequest, request);
+        OAuth2AccessToken token = userRequest.getAccessToken();
+        Map<String, Object> attributes = this.attributesConverter.convert(userRequest).convert(response.getBody());
+        Collection<GrantedAuthority> authorities = getAuthorities(token, attributes);
+        return new DefaultOAuth2User(authorities, attributes, userNameAttributeName);
+    }
+
+    /**
+     * Use this strategy to adapt user attributes into a format understood by Spring
+     * Security; by default, the original attributes are preserved.
+     *
+     * <p>
+     * This can be helpful, for example, if the user attribute is nested. Since Spring
+     * Security needs the username attribute to be at the top level, you can use this
+     * method to do:
+     *
+     * <pre>
+     *     DefaultOAuth2UserService userService = new DefaultOAuth2UserService();
+     *     userService.setAttributesConverter((userRequest) -> (attributes) ->
+     *         Map&lt;String, Object&gt; userObject = (Map&lt;String, Object&gt;) attributes.get("user");
+     *         attributes.put("user-name", userObject.get("user-name"));
+     *         return attributes;
+     *     });
+     * </pre>
+     * @param attributesConverter the attribute adaptation strategy to use
+     * @since 6.3
+     */
+    public void setAttributesConverter(
+            Converter<OAuth2UserRequest, Converter<Map<String, Object>, Map<String, Object>>> attributesConverter) {
+        Assert.notNull(attributesConverter, "attributesConverter cannot be null");
+        this.attributesConverter = attributesConverter;
+    }
+
+    private ResponseEntity<Map<String, Object>> getResponse(OAuth2UserRequest userRequest, RequestEntity<?> request) {
+        try {
+            return this.restOperations.exchange(request, PARAMETERIZED_RESPONSE_TYPE);
+        } catch (OAuth2AuthorizationException ex) {
+            OAuth2Error oauth2Error = ex.getError();
+            StringBuilder errorDetails = new StringBuilder();
+            errorDetails.append("Error details: [");
+            errorDetails.append("UserInfo Uri: ")
+                    .append(userRequest.getClientRegistration().getProviderDetails().getUserInfoEndpoint().getUri());
+            errorDetails.append(", Error Code: ").append(oauth2Error.getErrorCode());
+            if (oauth2Error.getDescription() != null) {
+                errorDetails.append(", Error Description: ").append(oauth2Error.getDescription());
+            }
+            errorDetails.append("]");
+            oauth2Error = new OAuth2Error(INVALID_USER_INFO_RESPONSE_ERROR_CODE,
+                    "An error occurred while attempting to retrieve the UserInfo Resource: " + errorDetails,
+                    null);
+            throw new OAuth2AuthenticationException(oauth2Error, oauth2Error.toString(), ex);
+        } catch (UnknownContentTypeException ex) {
+            String errorMessage = "An error occurred while attempting to retrieve the UserInfo Resource from '"
+                    + userRequest.getClientRegistration().getProviderDetails().getUserInfoEndpoint().getUri()
+                    + "': response contains invalid content type '" + ex.getContentType() + "'. "
+                    + "The UserInfo Response should return a JSON object (content type 'application/json') "
+                    + "that contains a collection of name and value pairs of the claims about the authenticated End-User. "
+                    + "Please ensure the UserInfo Uri in UserInfoEndpoint for Client Registration '"
+                    + userRequest.getClientRegistration().getRegistrationId() + "' conforms to the UserInfo Endpoint, "
+                    + "as defined in OpenID Connect 1.0: 'https://openid.net/specs/openid-connect-core-1_0.html#UserInfo'";
+            OAuth2Error oauth2Error = new OAuth2Error(INVALID_USER_INFO_RESPONSE_ERROR_CODE, errorMessage, null);
+            throw new OAuth2AuthenticationException(oauth2Error, oauth2Error.toString(), ex);
+        } catch (RestClientException ex) {
+            OAuth2Error oauth2Error = new OAuth2Error(INVALID_USER_INFO_RESPONSE_ERROR_CODE,
+                    "An error occurred while attempting to retrieve the UserInfo Resource: " + ex.getMessage(), null);
+            throw new OAuth2AuthenticationException(oauth2Error, oauth2Error.toString(), ex);
+        }
+    }
+
+    private String getUserNameAttributeName(OAuth2UserRequest userRequest) {
+        if (!StringUtils
+                .hasText(userRequest.getClientRegistration().getProviderDetails().getUserInfoEndpoint().getUri())) {
+            OAuth2Error oauth2Error = new OAuth2Error(MISSING_USER_INFO_URI_ERROR_CODE,
+                    "Missing required UserInfo Uri in UserInfoEndpoint for Client Registration: "
+                            + userRequest.getClientRegistration().getRegistrationId(),
+                    null);
+            throw new OAuth2AuthenticationException(oauth2Error, oauth2Error.toString());
+        }
+        String userNameAttributeName = userRequest.getClientRegistration()
+                .getProviderDetails()
+                .getUserInfoEndpoint()
+                .getUserNameAttributeName();
+        if (!StringUtils.hasText(userNameAttributeName)) {
+            OAuth2Error oauth2Error = new OAuth2Error(MISSING_USER_NAME_ATTRIBUTE_ERROR_CODE,
+                    "Missing required \"user name\" attribute name in UserInfoEndpoint for Client Registration: "
+                            + userRequest.getClientRegistration().getRegistrationId(),
+                    null);
+            throw new OAuth2AuthenticationException(oauth2Error, oauth2Error.toString());
+        }
+        return userNameAttributeName;
+    }
+
+    private Collection<GrantedAuthority> getAuthorities(OAuth2AccessToken token, Map<String, Object> attributes) {
+        Collection<GrantedAuthority> authorities = new LinkedHashSet<>();
+        authorities.add(new OAuth2UserAuthority(attributes));
+        for (String authority : token.getScopes()) {
+            authorities.add(new SimpleGrantedAuthority("SCOPE_" + authority));
+        }
+        return authorities;
+    }
+
+    /**
+     * Sets the {@link Converter} used for converting the {@link OAuth2UserRequest} to a
+     * {@link RequestEntity} representation of the UserInfo Request.
+     * @param requestEntityConverter the {@link Converter} used for converting to a
+     * {@link RequestEntity} representation of the UserInfo Request
+     * @since 5.1
+     */
+    public final void setRequestEntityConverter(Converter<OAuth2UserRequest, RequestEntity<?>> requestEntityConverter) {
+        Assert.notNull(requestEntityConverter, "requestEntityConverter cannot be null");
+        this.requestEntityConverter = requestEntityConverter;
+    }
+
+    /**
+     * Sets the {@link RestOperations} used when requesting the UserInfo resource.
+     *
+     * <p>
+     * <b>NOTE:</b> At a minimum, the supplied {@code restOperations} must be configured
+     * with the following:
+     * <ol>
+     * <li>{@link ResponseErrorHandler} - {@link OAuth2ErrorResponseErrorHandler}</li>
+     * </ol>
+     * @param restOperations the {@link RestOperations} used when requesting the UserInfo
+     * resource
+     * @since 5.1
+     */
+    public final void setRestOperations(RestOperations restOperations) {
+        Assert.notNull(restOperations, "restOperations cannot be null");
+        this.restOperations = restOperations;
+    }
+
+}

--- a/src/main/java/zip/ootd/ootdzip/oauth/service/CustomOAuth2UserService.java
+++ b/src/main/java/zip/ootd/ootdzip/oauth/service/CustomOAuth2UserService.java
@@ -58,10 +58,12 @@ public class CustomOAuth2UserService implements OAuth2UserService<OAuth2UserRequ
 
     private static final String INVALID_USER_INFO_RESPONSE_ERROR_CODE = "invalid_user_info_response";
 
-    private static final ParameterizedTypeReference<Map<String, Object>> PARAMETERIZED_RESPONSE_TYPE = new ParameterizedTypeReference<Map<String, Object>>() {
-    };
+    private static final ParameterizedTypeReference<Map<String, Object>> PARAMETERIZED_RESPONSE_TYPE =
+            new ParameterizedTypeReference<Map<String, Object>>() {
+            };
 
-    private Converter<OAuth2UserRequest, RequestEntity<?>> requestEntityConverter = new OAuth2UserRequestEntityConverter();
+    private Converter<OAuth2UserRequest, RequestEntity<?>> requestEntityConverter =
+            new OAuth2UserRequestEntityConverter();
 
     private Converter<OAuth2UserRequest, Converter<Map<String, Object>, Map<String, Object>>> attributesConverter = (
             request) -> (attributes) -> attributes;
@@ -134,8 +136,8 @@ public class CustomOAuth2UserService implements OAuth2UserService<OAuth2UserRequ
             String errorMessage = "An error occurred while attempting to retrieve the UserInfo Resource from '"
                     + userRequest.getClientRegistration().getProviderDetails().getUserInfoEndpoint().getUri()
                     + "': response contains invalid content type '" + ex.getContentType() + "'. "
-                    + "The UserInfo Response should return a JSON object (content type 'application/json') "
-                    + "that contains a collection of name and value pairs of the claims about the authenticated End-User. "
+                    + "The UserInfo Response should return a JSON object (content type 'application/json') that "
+                    + "contains a collection of name and value pairs of the claims about the authenticated End-User. "
                     + "Please ensure the UserInfo Uri in UserInfoEndpoint for Client Registration '"
                     + userRequest.getClientRegistration().getRegistrationId() + "' conforms to the UserInfo Endpoint, "
                     + "as defined in OpenID Connect 1.0: 'https://openid.net/specs/openid-connect-core-1_0.html#UserInfo'";

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -68,7 +68,7 @@ spring:
             authorization-uri: https://nid.naver.com/oauth2.0/authorize
             token-uri: https://nid.naver.com/oauth2.0/token
             user-info-uri: https://openapi.naver.com/v1/nid/me
-            user-name-attribute: response
+            user-name-attribute: response/id
 
   profiles:
     include: secret

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -37,6 +37,7 @@ spring:
             authorization-grant-type: authorization_code
             client-authentication-method: client_secret_post
             scope:
+              - openid
           kakao:
             redirect-uri: ${client.base-url}/sign-in/kakao/callback
             client-authentication-method: client_secret_post


### PR DESCRIPTION
### refactor
- `RegisteredOAuth2User` -> `AuthorizedUser`로 이름 변경
- apple, naver 로그인 분기 코드 리팩토링
### feature
- dev 로그인 시 `redirect_uri` 전달 기능 추가 (전달하지 않으면 기존 동작과 동일하고, 카카오 개발자 설정에서 전달할 Redirect URI를 추가해야 합니다.)