### PR TITLE
Feature/refactor follow count(#230)

### DIFF
--- a/src/main/java/zip/ootd/ootdzip/user/controller/response/CommonPageResponseForUserSearch.java
+++ b/src/main/java/zip/ootd/ootdzip/user/controller/response/CommonPageResponseForUserSearch.java
@@ -1,0 +1,26 @@
+package zip.ootd.ootdzip.user.controller.response;
+
+import java.util.List;
+
+import org.springframework.data.domain.Pageable;
+
+import lombok.Data;
+import lombok.EqualsAndHashCode;
+import zip.ootd.ootdzip.common.response.CommonPageResponse;
+
+@EqualsAndHashCode(callSuper = true)
+@Data
+public class CommonPageResponseForUserSearch<T> extends CommonPageResponse<T> {
+
+    Long followerCount;
+    Long followingCount;
+
+    public CommonPageResponseForUserSearch(List<T> content, Pageable pageable, Boolean isLast, Long total,
+            Long followerCount, Long followingCount) {
+
+        super(content, pageable, isLast, total);
+
+        this.followerCount = followerCount;
+        this.followingCount = followingCount;
+    }
+}

--- a/src/main/java/zip/ootd/ootdzip/user/controller/response/UserSearchRes.java
+++ b/src/main/java/zip/ootd/ootdzip/user/controller/response/UserSearchRes.java
@@ -16,8 +16,6 @@ public class UserSearchRes {
     private String profileImage;
     private String name;
     private Boolean isFollow;
-    private Long followerCount;
-    private Long followingCount;
 
     public static UserSearchRes of(User user, User loginUser) {
         return UserSearchRes.builder()
@@ -25,8 +23,7 @@ public class UserSearchRes {
                 .name(user.getName())
                 .profileImage(user.getProfileImage())
                 .isFollow(loginUser.isFollowing(user))
-                .followerCount(loginUser.getFollowerCount())
-                .followingCount(loginUser.getFollowingCount())
                 .build();
     }
 }
+

--- a/src/main/java/zip/ootd/ootdzip/user/repository/UserRepositoryCustom.java
+++ b/src/main/java/zip/ootd/ootdzip/user/repository/UserRepositoryCustom.java
@@ -5,12 +5,15 @@ import java.util.Set;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 
+import zip.ootd.ootdzip.user.data.UserSearchType;
 import zip.ootd.ootdzip.user.domain.User;
 
 public interface UserRepositoryCustom {
-    Page<User> searchUsers(String name, Set<Long> nonAccessibleUserIds, Pageable pageable);
 
-    Page<User> searchFollowers(String name, Long userId, Set<Long> nonAccessibleUserIds, Pageable pageable);
-
-    Page<User> searchFollowings(String name, Long userId, Set<Long> nonAccessibleUserIds, Pageable pageable);
+    Page<User> searchUsers(
+            UserSearchType searchType,
+            String name,
+            Long userId,
+            Set<Long> nonAccessibleUserIds,
+            Pageable pageable);
 }

--- a/src/main/java/zip/ootd/ootdzip/user/service/UserService.java
+++ b/src/main/java/zip/ootd/ootdzip/user/service/UserService.java
@@ -23,6 +23,7 @@ import zip.ootd.ootdzip.common.response.CommonPageResponse;
 import zip.ootd.ootdzip.notification.domain.NotificationType;
 import zip.ootd.ootdzip.notification.event.NotificationEvent;
 import zip.ootd.ootdzip.oauth.service.UserSocialLoginService;
+import zip.ootd.ootdzip.user.controller.response.CommonPageResponseForUserSearch;
 import zip.ootd.ootdzip.user.controller.response.ProfileRes;
 import zip.ootd.ootdzip.user.controller.response.UserInfoForMyPageRes;
 import zip.ootd.ootdzip.user.controller.response.UserSearchRes;
@@ -214,8 +215,8 @@ public class UserService {
                 .map((item) -> UserSearchRes.of(item, loginUser))
                 .toList();
 
-        return new CommonPageResponse<>(result, request.getPageable(), findUsers.isLast(),
-                findUsers.getTotalElements());
+        return new CommonPageResponseForUserSearch<>(result, request.getPageable(), findUsers.isLast(),
+                findUsers.getTotalElements(), loginUser.getFollowerCount(), loginUser.getFollowingCount());
     }
 
     public List<UserStyleRes> getUserStyle(User loginUser) {

--- a/src/main/java/zip/ootd/ootdzip/user/service/UserService.java
+++ b/src/main/java/zip/ootd/ootdzip/user/service/UserService.java
@@ -199,27 +199,16 @@ public class UserService {
 
     public CommonPageResponse<UserSearchRes> searchUser(UserSearchSvcReq request, User loginUser) {
 
-        Page<User> findUsers = null;
         UserSearchType userSearchType = request.getUserSearchType();
         Set<Long> nonAccessibleUserIds = userBlockRepository.getNonAccessibleUserIds(loginUser.getId());
 
-        if (userSearchType == UserSearchType.USER) {
-            findUsers = userRepository.searchUsers(request.getName(),
-                    nonAccessibleUserIds,
-                    request.getPageable());
-        } else if (userSearchType == UserSearchType.FOLLOWER) {
-            findUsers = userRepository.searchFollowers(request.getName(),
-                    request.getUserId(),
-                    nonAccessibleUserIds,
-                    request.getPageable());
-        } else if (userSearchType == UserSearchType.FOLLOWING) {
-            findUsers = userRepository.searchFollowings(request.getName(),
-                    request.getUserId(),
-                    nonAccessibleUserIds,
-                    request.getPageable());
-        } else {
-            throw new IllegalArgumentException("잘못된 검색 조건");
-        }
+        Page<User> findUsers = userRepository.searchUsers(
+                userSearchType,
+                request.getName(),
+                request.getUserId(),
+                nonAccessibleUserIds,
+                request.getPageable()
+        );
 
         List<UserSearchRes> result = findUsers.stream()
                 .map((item) -> UserSearchRes.of(item, loginUser))

--- a/src/test/java/zip/ootd/ootdzip/user/repository/UserRepositoryImplTest.java
+++ b/src/test/java/zip/ootd/ootdzip/user/repository/UserRepositoryImplTest.java
@@ -9,6 +9,7 @@ import org.springframework.data.domain.Slice;
 
 import zip.ootd.ootdzip.IntegrationTestSupport;
 import zip.ootd.ootdzip.common.request.CommonPageRequest;
+import zip.ootd.ootdzip.user.data.UserSearchType;
 import zip.ootd.ootdzip.user.domain.User;
 import zip.ootd.ootdzip.user.service.UserService;
 
@@ -31,7 +32,8 @@ public class UserRepositoryImplTest extends IntegrationTestSupport {
         CommonPageRequest pageRequest = new CommonPageRequest();
 
         // when
-        Slice<User> results = userRepository.searchUsers("감자", null, pageRequest.toPageable());
+        Slice<User> results = userRepository.searchUsers(UserSearchType.USER, "감자",
+                null, null, pageRequest.toPageable());
 
         // then
         assertThat(results).hasSize(2)
@@ -54,7 +56,8 @@ public class UserRepositoryImplTest extends IntegrationTestSupport {
         CommonPageRequest pageRequest = new CommonPageRequest();
 
         // when
-        Slice<User> results = userRepository.searchFollowers("", user.getId(), null, pageRequest.toPageable());
+        Slice<User> results = userRepository.searchUsers(UserSearchType.FOLLOWER, "", user.getId(),
+                null, pageRequest.toPageable());
 
         // then
         assertThat(results).hasSize(2)
@@ -79,7 +82,8 @@ public class UserRepositoryImplTest extends IntegrationTestSupport {
         CommonPageRequest pageRequest = new CommonPageRequest();
 
         // when
-        Slice<User> results = userRepository.searchFollowers("감", user.getId(), null, pageRequest.toPageable());
+        Slice<User> results = userRepository.searchUsers(UserSearchType.FOLLOWER, "감",
+                user.getId(), null, pageRequest.toPageable());
 
         // then
         assertThat(results).hasSize(2)
@@ -104,7 +108,8 @@ public class UserRepositoryImplTest extends IntegrationTestSupport {
         CommonPageRequest pageRequest = new CommonPageRequest();
 
         // when
-        Slice<User> results = userRepository.searchFollowings("", user.getId(), null, pageRequest.toPageable());
+        Slice<User> results = userRepository.searchUsers(UserSearchType.FOLLOWING, "",
+                user.getId(), null, pageRequest.toPageable());
 
         // then
         assertThat(results).hasSize(3)
@@ -128,7 +133,8 @@ public class UserRepositoryImplTest extends IntegrationTestSupport {
         CommonPageRequest pageRequest = new CommonPageRequest();
 
         // when
-        Slice<User> results = userRepository.searchFollowings("감", user.getId(), null, pageRequest.toPageable());
+        Slice<User> results = userRepository.searchUsers(UserSearchType.FOLLOWING, "감",
+                user.getId(), null, pageRequest.toPageable());
 
         // then
         assertThat(results).hasSize(2)

--- a/src/test/java/zip/ootd/ootdzip/user/service/UserServiceTest.java
+++ b/src/test/java/zip/ootd/ootdzip/user/service/UserServiceTest.java
@@ -663,6 +663,7 @@ class UserServiceTest extends IntegrationTestSupport {
     private User createUserBy(String userName) {
         User user = User.getDefault();
         user.setName(userName);
+        user.setIsCompleted(true);
         return userRepository.save(user);
     }
 


### PR DESCRIPTION
## 변경사항
- 유저 검색 로직 리팩토링(가독성 개선)
- 팔로워/팔로잉 개수 반환 로직 리팩토링(성능 개선)

## 참고사항
기존에 유저검색시에 반환되는 팔로워/팔로잉 로직의 경우 DTO 마다 팔로워/팔로잉 개수를 호출하여 불필요하게 반복문을 호출 했습니다. 로직상 팔로워/팔로잉 호출은 O(n) 이고, 이걸 유저마다 호출하면 O(n^2) 입니다. 다행히도 DB 는 하이버네이트가 최적화를 해줘서 반복적으로 쿼리를 날리지 않고 한번만 날리긴 합니다만 서버상에 부하가 있기에 이를 수정해 O(n) 이 되도록 했습니다. 새로운 `CommonPageResponseForUserSearch` DTO 를 만들어 팔로워/팔로잉 개수를 한번만 호출하도록 수정했습니다.

close #230