### PR TITLE
브랜드 요청 관리 기능 추가

### DIFF
--- a/src/main/java/zip/ootd/ootdzip/brand/repository/BrandRepository.java
+++ b/src/main/java/zip/ootd/ootdzip/brand/repository/BrandRepository.java
@@ -1,6 +1,7 @@
 package zip.ootd.ootdzip.brand.repository;
 
 import java.util.List;
+import java.util.Optional;
 
 import org.springframework.data.domain.Sort;
 import org.springframework.data.jpa.repository.JpaRepository;
@@ -13,7 +14,9 @@ public interface BrandRepository extends JpaRepository<Brand, Long>, BrandReposi
 
     Boolean existsByName(String name);
 
+    Boolean existsByEngName(String engName);
+
     List<Brand> findByNameStartsWithOrEngNameStartsWith(String name, String engName, Sort sort);
 
-    Brand findOneByName(String name);
+    Optional<Brand> findOneByName(String name);
 }

--- a/src/main/java/zip/ootd/ootdzip/brandrequest/controller/BrandRequestController.java
+++ b/src/main/java/zip/ootd/ootdzip/brandrequest/controller/BrandRequestController.java
@@ -24,7 +24,7 @@ public class BrandRequestController {
 
     @PostMapping
     public ApiResponse<String> insertBrandRequest(@Valid @RequestBody BrandRequestReq request) {
-        brandRequestService.insertBrandReqeust(request.toServiceRequest(), userService.getAuthenticatiedUser());
+        brandRequestService.insertBrandRequest(request.toServiceRequest(), userService.getAuthenticatiedUser());
         return new ApiResponse<>("OK");
     }
 

--- a/src/main/java/zip/ootd/ootdzip/brandrequest/controller/BrandRequestController.java
+++ b/src/main/java/zip/ootd/ootdzip/brandrequest/controller/BrandRequestController.java
@@ -9,6 +9,7 @@ import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import zip.ootd.ootdzip.brandrequest.controller.reqeuest.BrandRequestApproveReq;
+import zip.ootd.ootdzip.brandrequest.controller.reqeuest.BrandRequestRejectReq;
 import zip.ootd.ootdzip.brandrequest.controller.reqeuest.BrandRequestReq;
 import zip.ootd.ootdzip.brandrequest.service.BrandRequestService;
 import zip.ootd.ootdzip.common.response.ApiResponse;
@@ -32,6 +33,12 @@ public class BrandRequestController {
     @PostMapping("/api/admin/approve-brand-request")
     public ApiResponse<String> approveBrandRequest(@Valid @RequestBody BrandRequestApproveReq request) {
         brandRequestService.approveBrandRequest(request.toServiceRequest(), userService.getAuthenticatiedUser());
+        return new ApiResponse<>("OK");
+    }
+
+    @PostMapping("/api/admin/reject-brand-request")
+    public ApiResponse<String> rejectBrandRequest(@Valid @RequestBody BrandRequestRejectReq request) {
+        brandRequestService.rejectBrandRequest(request.toServiceRequest(), userService.getAuthenticatiedUser());
         return new ApiResponse<>("OK");
     }
 

--- a/src/main/java/zip/ootd/ootdzip/brandrequest/controller/BrandRequestController.java
+++ b/src/main/java/zip/ootd/ootdzip/brandrequest/controller/BrandRequestController.java
@@ -8,6 +8,7 @@ import org.springframework.web.bind.annotation.RestController;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
+import zip.ootd.ootdzip.brandrequest.controller.reqeuest.BrandRequestApproveReq;
 import zip.ootd.ootdzip.brandrequest.controller.reqeuest.BrandRequestReq;
 import zip.ootd.ootdzip.brandrequest.service.BrandRequestService;
 import zip.ootd.ootdzip.common.response.ApiResponse;
@@ -25,6 +26,12 @@ public class BrandRequestController {
     @PostMapping
     public ApiResponse<String> insertBrandRequest(@Valid @RequestBody BrandRequestReq request) {
         brandRequestService.insertBrandRequest(request.toServiceRequest(), userService.getAuthenticatiedUser());
+        return new ApiResponse<>("OK");
+    }
+
+    @PostMapping("/api/admin/approve-brand-request")
+    public ApiResponse<String> approveBrandRequest(@Valid @RequestBody BrandRequestApproveReq request) {
+        brandRequestService.approveBrandRequest(request.toServiceRequest(), userService.getAuthenticatiedUser());
         return new ApiResponse<>("OK");
     }
 

--- a/src/main/java/zip/ootd/ootdzip/brandrequest/controller/BrandRequestController.java
+++ b/src/main/java/zip/ootd/ootdzip/brandrequest/controller/BrandRequestController.java
@@ -1,5 +1,6 @@
 package zip.ootd.ootdzip.brandrequest.controller;
 
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -11,8 +12,11 @@ import lombok.RequiredArgsConstructor;
 import zip.ootd.ootdzip.brandrequest.controller.reqeuest.BrandRequestApproveReq;
 import zip.ootd.ootdzip.brandrequest.controller.reqeuest.BrandRequestRejectReq;
 import zip.ootd.ootdzip.brandrequest.controller.reqeuest.BrandRequestReq;
+import zip.ootd.ootdzip.brandrequest.controller.reqeuest.BrandRequestSearchReq;
+import zip.ootd.ootdzip.brandrequest.controller.response.BrandRequestSearchRes;
 import zip.ootd.ootdzip.brandrequest.service.BrandRequestService;
 import zip.ootd.ootdzip.common.response.ApiResponse;
+import zip.ootd.ootdzip.common.response.CommonPageResponse;
 import zip.ootd.ootdzip.user.service.UserService;
 
 @RestController
@@ -40,6 +44,13 @@ public class BrandRequestController {
     public ApiResponse<String> rejectBrandRequest(@Valid @RequestBody BrandRequestRejectReq request) {
         brandRequestService.rejectBrandRequest(request.toServiceRequest(), userService.getAuthenticatiedUser());
         return new ApiResponse<>("OK");
+    }
+
+    @GetMapping("/api/admin/brand-request")
+    public ApiResponse<CommonPageResponse<BrandRequestSearchRes>> searchBrandRequest(
+            @Valid @RequestBody BrandRequestSearchReq request) {
+        return new ApiResponse<>(brandRequestService.searchBrandRequest(request.toServiceRequest(),
+                userService.getAuthenticatiedUser()));
     }
 
 }

--- a/src/main/java/zip/ootd/ootdzip/brandrequest/controller/reqeuest/BrandRequestApproveReq.java
+++ b/src/main/java/zip/ootd/ootdzip/brandrequest/controller/reqeuest/BrandRequestApproveReq.java
@@ -1,0 +1,28 @@
+package zip.ootd.ootdzip.brandrequest.controller.reqeuest;
+
+import java.util.List;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotEmpty;
+import zip.ootd.ootdzip.brandrequest.service.request.BrandRequestApproveSvcReq;
+
+public class BrandRequestApproveReq {
+
+    @NotEmpty(message = "브랜드 요청 ID는 필수입니다.")
+    private List<Long> brandRequestId;
+
+    @NotBlank(message = "브랜드명은 필수입니다.")
+    private String brandName;
+
+    @NotBlank(message = "브랜드 영문명은 필수입니다.")
+    private String brandEngName;
+
+    public BrandRequestApproveSvcReq toServiceRequest() {
+        return BrandRequestApproveSvcReq.builder()
+                .brandRequestId(brandRequestId)
+                .brandName(brandName)
+                .brandEngName(brandEngName)
+                .build();
+    }
+
+}

--- a/src/main/java/zip/ootd/ootdzip/brandrequest/controller/reqeuest/BrandRequestApproveReq.java
+++ b/src/main/java/zip/ootd/ootdzip/brandrequest/controller/reqeuest/BrandRequestApproveReq.java
@@ -4,8 +4,12 @@ import java.util.List;
 
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotEmpty;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
 import zip.ootd.ootdzip.brandrequest.service.request.BrandRequestApproveSvcReq;
 
+@Getter
+@NoArgsConstructor
 public class BrandRequestApproveReq {
 
     @NotEmpty(message = "브랜드 요청 ID는 필수입니다.")

--- a/src/main/java/zip/ootd/ootdzip/brandrequest/controller/reqeuest/BrandRequestRejectReq.java
+++ b/src/main/java/zip/ootd/ootdzip/brandrequest/controller/reqeuest/BrandRequestRejectReq.java
@@ -1,0 +1,27 @@
+package zip.ootd.ootdzip.brandrequest.controller.reqeuest;
+
+import java.util.List;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotEmpty;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import zip.ootd.ootdzip.brandrequest.service.request.BrandRequestRejectSvcReq;
+
+@Getter
+@NoArgsConstructor
+public class BrandRequestRejectReq {
+
+    @NotEmpty(message = "브랜드 요청 ID는 필수입니다.")
+    private List<Long> brandRequestId;
+
+    @NotBlank(message = "거절 사유는 필수입니다.")
+    private String reason;
+
+    public BrandRequestRejectSvcReq toServiceRequest() {
+        return BrandRequestRejectSvcReq.builder()
+                .brandRequestId(brandRequestId)
+                .reason(reason)
+                .build();
+    }
+}

--- a/src/main/java/zip/ootd/ootdzip/brandrequest/controller/reqeuest/BrandRequestSearchReq.java
+++ b/src/main/java/zip/ootd/ootdzip/brandrequest/controller/reqeuest/BrandRequestSearchReq.java
@@ -1,0 +1,40 @@
+package zip.ootd.ootdzip.brandrequest.controller.reqeuest;
+
+import java.util.List;
+
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Sort;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import zip.ootd.ootdzip.brandrequest.data.BrandRequestStatus;
+import zip.ootd.ootdzip.brandrequest.service.request.BrandRequestSearchSvcReq;
+import zip.ootd.ootdzip.common.request.SortColumn;
+
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+@Getter
+public class BrandRequestSearchReq {
+
+    private BrandRequestStatus searchStatus;
+    private String searchText;
+    private Integer pageNo;
+    private Integer pageSize;
+    private List<SortColumn> sortColumns;
+
+    public BrandRequestSearchSvcReq toServiceRequest() {
+        Sort sort = Sort.unsorted();
+        sortColumns.stream().forEach((sortColumn -> {
+            sort.and(sortColumn.toSort());
+        }));
+
+        return BrandRequestSearchSvcReq.builder()
+                .searchStatus(searchStatus)
+                .searchText(searchText)
+                .pageable(PageRequest.of(pageNo, pageSize, sort))
+                .build();
+    }
+}

--- a/src/main/java/zip/ootd/ootdzip/brandrequest/controller/response/BrandRequestSearchRes.java
+++ b/src/main/java/zip/ootd/ootdzip/brandrequest/controller/response/BrandRequestSearchRes.java
@@ -1,0 +1,33 @@
+package zip.ootd.ootdzip.brandrequest.controller.response;
+
+import java.time.LocalDateTime;
+
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import zip.ootd.ootdzip.brandrequest.data.BrandRequestStatus;
+import zip.ootd.ootdzip.brandrequest.domain.BrandRequest;
+
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+@Builder
+@Getter
+public class BrandRequestSearchRes {
+    private Long id;
+    private String requestUserName;
+    private String requestContents;
+    private BrandRequestStatus brandRequestStatus;
+    private LocalDateTime createdAt;
+
+    public static BrandRequestSearchRes of(BrandRequest brandRequest) {
+        return BrandRequestSearchRes.builder()
+                .id(brandRequest.getId())
+                .requestUserName(brandRequest.getRequestUser().getName())
+                .requestContents(brandRequest.getRequestContents())
+                .brandRequestStatus(brandRequest.getRequestStatus())
+                .createdAt(brandRequest.getCreatedAt())
+                .build();
+    }
+}

--- a/src/main/java/zip/ootd/ootdzip/brandrequest/domain/BrandRequest.java
+++ b/src/main/java/zip/ootd/ootdzip/brandrequest/domain/BrandRequest.java
@@ -45,4 +45,9 @@ public class BrandRequest extends BaseEntity {
         requestStatus = BrandRequestStatus.APPROVED;
     }
 
+    public void rejectBrandRequest(String reason) {
+        requestStatus = BrandRequestStatus.REJECTION;
+        this.reason = reason;
+    }
+
 }

--- a/src/main/java/zip/ootd/ootdzip/brandrequest/domain/BrandRequest.java
+++ b/src/main/java/zip/ootd/ootdzip/brandrequest/domain/BrandRequest.java
@@ -40,4 +40,9 @@ public class BrandRequest extends BaseEntity {
                 .requestStatus(BrandRequestStatus.REQUEST)
                 .build();
     }
+
+    public void approveBrandRequest() {
+        requestStatus = BrandRequestStatus.APPROVED;
+    }
+
 }

--- a/src/main/java/zip/ootd/ootdzip/brandrequest/repository/BrandRequestRepository.java
+++ b/src/main/java/zip/ootd/ootdzip/brandrequest/repository/BrandRequestRepository.java
@@ -1,5 +1,8 @@
 package zip.ootd.ootdzip.brandrequest.repository;
 
+import java.util.List;
+import java.util.Optional;
+
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
@@ -8,4 +11,7 @@ import zip.ootd.ootdzip.brandrequest.domain.BrandRequest;
 @Repository
 public interface BrandRequestRepository extends JpaRepository<BrandRequest, Long> {
 
+    Optional<BrandRequest> findOneByRequestContents(String requestContents);
+
+    List<BrandRequest> findByIdIn(List<Long> ids);
 }

--- a/src/main/java/zip/ootd/ootdzip/brandrequest/repository/BrandRequestRepository.java
+++ b/src/main/java/zip/ootd/ootdzip/brandrequest/repository/BrandRequestRepository.java
@@ -9,7 +9,7 @@ import org.springframework.stereotype.Repository;
 import zip.ootd.ootdzip.brandrequest.domain.BrandRequest;
 
 @Repository
-public interface BrandRequestRepository extends JpaRepository<BrandRequest, Long> {
+public interface BrandRequestRepository extends JpaRepository<BrandRequest, Long>, BrandRequestRepositoryCustom {
 
     Optional<BrandRequest> findOneByRequestContents(String requestContents);
 

--- a/src/main/java/zip/ootd/ootdzip/brandrequest/repository/BrandRequestRepositoryCustom.java
+++ b/src/main/java/zip/ootd/ootdzip/brandrequest/repository/BrandRequestRepositoryCustom.java
@@ -1,0 +1,11 @@
+package zip.ootd.ootdzip.brandrequest.repository;
+
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+
+import zip.ootd.ootdzip.brandrequest.domain.BrandRequest;
+import zip.ootd.ootdzip.brandrequest.repository.model.BrandRequestSearchRepoParam;
+
+public interface BrandRequestRepositoryCustom {
+    Page<BrandRequest> searchBrandRequests(BrandRequestSearchRepoParam param, Pageable pageable);
+}

--- a/src/main/java/zip/ootd/ootdzip/brandrequest/repository/BrandRequestRepositoryImpl.java
+++ b/src/main/java/zip/ootd/ootdzip/brandrequest/repository/BrandRequestRepositoryImpl.java
@@ -1,0 +1,77 @@
+package zip.ootd.ootdzip.brandrequest.repository;
+
+import static zip.ootd.ootdzip.brandrequest.domain.QBrandRequest.*;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
+import org.springframework.data.jpa.repository.support.QuerydslRepositorySupport;
+import org.springframework.data.support.PageableExecutionUtils;
+import org.springframework.stereotype.Repository;
+
+import com.querydsl.core.types.Order;
+import com.querydsl.core.types.OrderSpecifier;
+import com.querydsl.core.types.dsl.BooleanExpression;
+import com.querydsl.core.types.dsl.PathBuilder;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+
+import zip.ootd.ootdzip.brandrequest.data.BrandRequestStatus;
+import zip.ootd.ootdzip.brandrequest.domain.BrandRequest;
+import zip.ootd.ootdzip.brandrequest.repository.model.BrandRequestSearchRepoParam;
+
+@Repository
+public class BrandRequestRepositoryImpl extends QuerydslRepositorySupport implements BrandRequestRepositoryCustom {
+
+    private final JPAQueryFactory queryFactory;
+
+    public BrandRequestRepositoryImpl(JPAQueryFactory queryFactory) {
+        super(BrandRequest.class);
+        this.queryFactory = queryFactory;
+    }
+
+    @Override
+    public Page<BrandRequest> searchBrandRequests(BrandRequestSearchRepoParam param, Pageable pageable) {
+        List<BrandRequest> contents = queryFactory.selectFrom(brandRequest)
+                .where(searchTextCondition(param.getSearchText()),
+                        brandRequestStatusEq(param.getBrandRequestStatus()))
+                .orderBy(getOrderSpecifier(pageable.getSort()))
+                .offset(pageable.getOffset())
+                .limit(pageable.getPageSize())
+                .fetch();
+
+        Long totalCount = queryFactory.select(brandRequest.count())
+                .from(brandRequest)
+                .where(searchTextCondition(param.getSearchText()),
+                        brandRequestStatusEq(param.getBrandRequestStatus()))
+                .fetchOne();
+
+        return PageableExecutionUtils.getPage(contents, pageable, () -> totalCount);
+    }
+
+    private BooleanExpression searchTextCondition(String searchText) {
+        return searchText == null ? null
+                : brandRequest.requestContents.contains(searchText)
+                .or(brandRequest.requestUser.name.contains(searchText));
+
+    }
+
+    private BooleanExpression brandRequestStatusEq(BrandRequestStatus status) {
+        return status == null ? null : brandRequest.requestStatus.eq(status);
+    }
+
+    private OrderSpecifier[] getOrderSpecifier(Sort sort) {
+        List<OrderSpecifier> orders = new ArrayList<>();
+
+        sort.stream().forEach(order -> {
+            Order direction = order.isAscending() ? Order.ASC : Order.DESC;
+            String property = order.getProperty();
+            PathBuilder orderByExpression = new PathBuilder(BrandRequest.class, "brandRequest");
+            orders.add(new OrderSpecifier(direction, orderByExpression.get(property)));
+        });
+
+        return orders.stream().toArray(OrderSpecifier[]::new);
+    }
+}

--- a/src/main/java/zip/ootd/ootdzip/brandrequest/repository/model/BrandRequestSearchRepoParam.java
+++ b/src/main/java/zip/ootd/ootdzip/brandrequest/repository/model/BrandRequestSearchRepoParam.java
@@ -1,0 +1,17 @@
+package zip.ootd.ootdzip.brandrequest.repository.model;
+
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import zip.ootd.ootdzip.brandrequest.data.BrandRequestStatus;
+
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+@Getter
+@Builder
+public class BrandRequestSearchRepoParam {
+    private BrandRequestStatus brandRequestStatus;
+    private String searchText;
+}

--- a/src/main/java/zip/ootd/ootdzip/brandrequest/service/BrandRequestService.java
+++ b/src/main/java/zip/ootd/ootdzip/brandrequest/service/BrandRequestService.java
@@ -1,15 +1,22 @@
 package zip.ootd.ootdzip.brandrequest.service;
 
+import java.util.List;
+
+import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import lombok.RequiredArgsConstructor;
+import zip.ootd.ootdzip.brand.domain.Brand;
+import zip.ootd.ootdzip.brand.repository.BrandRepository;
 import zip.ootd.ootdzip.brandrequest.domain.BrandRequest;
 import zip.ootd.ootdzip.brandrequest.repository.BrandRequestRepository;
 import zip.ootd.ootdzip.brandrequest.service.request.BrandRequestApproveSvcReq;
 import zip.ootd.ootdzip.brandrequest.service.request.BrandRequestSvcReq;
 import zip.ootd.ootdzip.common.exception.CustomException;
 import zip.ootd.ootdzip.common.exception.code.ErrorCode;
+import zip.ootd.ootdzip.notification.domain.NotificationType;
+import zip.ootd.ootdzip.notification.event.NotificationEvent;
 import zip.ootd.ootdzip.user.domain.User;
 
 @Service
@@ -18,9 +25,11 @@ import zip.ootd.ootdzip.user.domain.User;
 public class BrandRequestService {
 
     private final BrandRequestRepository brandRequestRepository;
+    private final BrandRepository brandRepository;
+    private final ApplicationEventPublisher eventPublisher;
 
     @Transactional
-    public void insertBrandReqeust(BrandRequestSvcReq request, User loginUser) {
+    public void insertBrandRequest(BrandRequestSvcReq request, User loginUser) {
 
         if (request.getRequestContents().isBlank()) {
             throw new CustomException(ErrorCode.REQUIRED_BRAND_REQUEST_NAME);
@@ -34,5 +43,41 @@ public class BrandRequestService {
     @Transactional
     public void approveBrandRequest(BrandRequestApproveSvcReq request, User loginUser) {
 
+        if (!loginUser.isAdmin()) {
+            throw new CustomException(ErrorCode.FORBIDDEN_ERROR);
+        }
+
+        List<BrandRequest> approveTargets = brandRequestRepository.findByIdIn(request.getBrandRequestId());
+
+        if (approveTargets.size() != request.getBrandRequestId().size()) {
+            throw new CustomException(ErrorCode.INVALID_BRAND_REQUEST_ID);
+        }
+
+        if (brandRepository.existsByName(request.getBrandName())) {
+            throw new CustomException(ErrorCode.EXISTED_BRAND_NAME);
+        }
+
+        if (brandRepository.existsByEngName(request.getBrandEngName())) {
+            throw new CustomException(ErrorCode.EXISTED_BRAND_ENG_NAME);
+        }
+
+        Brand brand = Brand.builder()
+                .name(request.getBrandName())
+                .engName(request.getBrandEngName())
+                .build();
+
+        approveTargets.forEach((brandRequest) -> {
+            eventPublisher.publishEvent(NotificationEvent.builder()
+                    .receiver(brandRequest.getRequestUser())
+                    .sender(brandRequest.getRequestUser())
+                    .notificationType(NotificationType.BRAND_REQUEST_APPROVED)
+                    .goUrl("")
+                    .imageUrl(brandRequest.getRequestUser().getImages().getImageUrlSmall())
+                    .content(String.format("%s(%s)가 추가되었습니다.", brand.getName(), brand.getEngName()))
+                    .build());
+            brandRequest.approveBrandRequest();
+        });
+
+        brandRepository.save(brand);
     }
 }

--- a/src/main/java/zip/ootd/ootdzip/brandrequest/service/BrandRequestService.java
+++ b/src/main/java/zip/ootd/ootdzip/brandrequest/service/BrandRequestService.java
@@ -12,6 +12,7 @@ import zip.ootd.ootdzip.brand.repository.BrandRepository;
 import zip.ootd.ootdzip.brandrequest.domain.BrandRequest;
 import zip.ootd.ootdzip.brandrequest.repository.BrandRequestRepository;
 import zip.ootd.ootdzip.brandrequest.service.request.BrandRequestApproveSvcReq;
+import zip.ootd.ootdzip.brandrequest.service.request.BrandRequestRejectSvcReq;
 import zip.ootd.ootdzip.brandrequest.service.request.BrandRequestSvcReq;
 import zip.ootd.ootdzip.common.exception.CustomException;
 import zip.ootd.ootdzip.common.exception.code.ErrorCode;
@@ -79,5 +80,10 @@ public class BrandRequestService {
         });
 
         brandRepository.save(brand);
+    }
+
+    @Transactional
+    public void rejectBrandRequest(BrandRequestRejectSvcReq request, User loginUser) {
+
     }
 }

--- a/src/main/java/zip/ootd/ootdzip/brandrequest/service/request/BrandRequestRejectSvcReq.java
+++ b/src/main/java/zip/ootd/ootdzip/brandrequest/service/request/BrandRequestRejectSvcReq.java
@@ -1,0 +1,18 @@
+package zip.ootd.ootdzip.brandrequest.service.request;
+
+import java.util.List;
+
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@NoArgsConstructor
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+@Builder
+@Getter
+public class BrandRequestRejectSvcReq {
+    private List<Long> brandRequestId;
+    private String reason;
+}

--- a/src/main/java/zip/ootd/ootdzip/brandrequest/service/request/BrandRequestSearchSvcReq.java
+++ b/src/main/java/zip/ootd/ootdzip/brandrequest/service/request/BrandRequestSearchSvcReq.java
@@ -1,0 +1,21 @@
+package zip.ootd.ootdzip.brandrequest.service.request;
+
+import org.springframework.data.domain.Pageable;
+
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import zip.ootd.ootdzip.brandrequest.data.BrandRequestStatus;
+
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+@Builder
+@Getter
+public class BrandRequestSearchSvcReq {
+
+    private String searchText;
+    private BrandRequestStatus searchStatus;
+    private Pageable pageable;
+}

--- a/src/main/java/zip/ootd/ootdzip/common/exception/code/ErrorCode.java
+++ b/src/main/java/zip/ootd/ootdzip/common/exception/code/ErrorCode.java
@@ -163,7 +163,9 @@ public enum ErrorCode {
 
     EXISTED_BRAND_NAME(400, "BR004", "이미 존재하는 브랜드명입니다."),
 
-    EXISTED_BRAND_ENG_NAME(400, "BR005", "이미 존재하는 영문 브랜드명입니다.");
+    EXISTED_BRAND_ENG_NAME(400, "BR005", "이미 존재하는 영문 브랜드명입니다."),
+
+    REQUIRED_REJECT_REASON(400, "BR006", "거절 사유를 입력해주세요.");
 
     private final Integer status;
 

--- a/src/main/java/zip/ootd/ootdzip/common/exception/code/ErrorCode.java
+++ b/src/main/java/zip/ootd/ootdzip/common/exception/code/ErrorCode.java
@@ -157,7 +157,19 @@ public enum ErrorCode {
 
     INVALID_PURCHASE_STORE_TYPE(404, "C007", "유효하지 않은 구매처 타입"),
 
-    REQUIRED_BRAND_REQUEST_NAME(400, "BR001", "브랜드 요청 내용은 필수입니다.");
+    REQUIRED_BRAND_REQUEST_NAME(400, "BR001", "브랜드 요청 내용은 필수입니다."),
+
+    REQUIRED_BRAND_REQUEST_ID(400, "BR002", "브랜드 요청 ID는 필수입니다."),
+
+    INVALID_BRAND_REQUEST_ID(404, "BR003", "유효하지 않은 브랜드 요청 ID가 있습니다."),
+
+    EXISTED_BRAND_NAME(400, "BR004", "이미 존재하는 브랜드명입니다."),
+
+    EXISTED_BRAND_ENG_NAME(400, "BR005", "이미 존재하는 영문 브랜드명입니다."),
+
+    REQUIRED_BRAND_REQUEST_BRAND_NAME(400, "BR006", "브랜드명은 필수입니다."),
+
+    REQUIRED_BRAND_REQUEST_BRAND_ENG_NAME(400, "BR007", "영문 브랜드명은 필수입니다.");
 
     private final Integer status;
 

--- a/src/main/java/zip/ootd/ootdzip/common/exception/code/ErrorCode.java
+++ b/src/main/java/zip/ootd/ootdzip/common/exception/code/ErrorCode.java
@@ -159,17 +159,11 @@ public enum ErrorCode {
 
     REQUIRED_BRAND_REQUEST_NAME(400, "BR001", "브랜드 요청 내용은 필수입니다."),
 
-    REQUIRED_BRAND_REQUEST_ID(400, "BR002", "브랜드 요청 ID는 필수입니다."),
-
     INVALID_BRAND_REQUEST_ID(404, "BR003", "유효하지 않은 브랜드 요청 ID가 있습니다."),
 
     EXISTED_BRAND_NAME(400, "BR004", "이미 존재하는 브랜드명입니다."),
 
-    EXISTED_BRAND_ENG_NAME(400, "BR005", "이미 존재하는 영문 브랜드명입니다."),
-
-    REQUIRED_BRAND_REQUEST_BRAND_NAME(400, "BR006", "브랜드명은 필수입니다."),
-
-    REQUIRED_BRAND_REQUEST_BRAND_ENG_NAME(400, "BR007", "영문 브랜드명은 필수입니다.");
+    EXISTED_BRAND_ENG_NAME(400, "BR005", "이미 존재하는 영문 브랜드명입니다.");
 
     private final Integer status;
 

--- a/src/main/java/zip/ootd/ootdzip/common/request/SortColumn.java
+++ b/src/main/java/zip/ootd/ootdzip/common/request/SortColumn.java
@@ -1,0 +1,21 @@
+package zip.ootd.ootdzip.common.request;
+
+import org.springframework.data.domain.Sort;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+@Getter
+public class SortColumn {
+    private String sortCriteria;
+    private Sort.Direction sortDirection;
+
+    public Sort toSort() {
+        return Sort.by(sortDirection, sortCriteria);
+    }
+}

--- a/src/main/java/zip/ootd/ootdzip/common/response/CommonPageResponse.java
+++ b/src/main/java/zip/ootd/ootdzip/common/response/CommonPageResponse.java
@@ -21,11 +21,22 @@ public class CommonPageResponse<T> {
 
     private Long total;
 
+    private Integer totalPageCount;
+
     public CommonPageResponse(List<T> content, Pageable pageable, Boolean isLast, Long total) {
         this.content = content;
         this.page = pageable.getPageNumber();
         this.size = pageable.getPageSize();
         this.isLast = isLast;
         this.total = total;
+    }
+
+    public CommonPageResponse(List<T> content, Pageable pageable, Boolean isLast, Long total, Integer totalPageCount) {
+        this.content = content;
+        this.page = pageable.getPageNumber();
+        this.size = pageable.getPageSize();
+        this.isLast = isLast;
+        this.total = total;
+        this.totalPageCount = totalPageCount;
     }
 }

--- a/src/main/java/zip/ootd/ootdzip/notification/domain/NotificationType.java
+++ b/src/main/java/zip/ootd/ootdzip/notification/domain/NotificationType.java
@@ -7,7 +7,8 @@ public enum NotificationType {
     FOLLOW("님이 회원님을 팔로우합니다."),
     OOTD_COMMENT("님이 회원님의 ootd에 댓글을 남겼습니다."),
     TAG_COMMENT("님이 회원님의 댓글에 답글을 남겼습니다."),
-    LIKE("님이 회원님의 ootd를 좋아합니다.");
+    LIKE("님이 회원님의 ootd를 좋아합니다."),
+    BRAND_REQUEST_APPROVED("님이 건의한 브랜드가 추가되었습니다.");
 
     private final String baseMessage;
 

--- a/src/main/java/zip/ootd/ootdzip/notification/domain/NotificationType.java
+++ b/src/main/java/zip/ootd/ootdzip/notification/domain/NotificationType.java
@@ -8,7 +8,8 @@ public enum NotificationType {
     OOTD_COMMENT("님이 회원님의 ootd에 댓글을 남겼습니다."),
     TAG_COMMENT("님이 회원님의 댓글에 답글을 남겼습니다."),
     LIKE("님이 회원님의 ootd를 좋아합니다."),
-    BRAND_REQUEST_APPROVED("님이 건의한 브랜드가 추가되었습니다.");
+    BRAND_REQUEST_APPROVED("님이 건의한 브랜드가 추가되었습니다."),
+    BRAND_REQUEST_REJECTED("님이 건의한 브랜드가 거절되었습니다.");
 
     private final String baseMessage;
 

--- a/src/main/java/zip/ootd/ootdzip/user/domain/User.java
+++ b/src/main/java/zip/ootd/ootdzip/user/domain/User.java
@@ -226,4 +226,8 @@ public class User extends BaseEntity {
         }
         return images;
     }
+
+    public boolean isAdmin() {
+        return userRole.equals(UserRole.ADMIN);
+    }
 }

--- a/src/test/java/zip/ootd/ootdzip/brandrequest/controller/BrandRequestControllerTest.java
+++ b/src/test/java/zip/ootd/ootdzip/brandrequest/controller/BrandRequestControllerTest.java
@@ -45,7 +45,7 @@ class BrandRequestControllerTest extends ControllerTestSupport {
                 .andDo(print())
                 .andExpect(status().isNotFound())
                 .andExpect(MockMvcResultMatchers.jsonPath("$.statusCode").value(404))
-                .andExpect(MockMvcResultMatchers.jsonPath("$.errors[0].field").value("requestName"))
+                .andExpect(MockMvcResultMatchers.jsonPath("$.errors[0].field").value("requestContents"))
                 .andExpect(MockMvcResultMatchers.jsonPath("$.errors[0].reason").value("브랜드 요청 내용은 필수입니다."));
     }
 

--- a/src/test/java/zip/ootd/ootdzip/brandrequest/service/BrandRequestServiceTest.java
+++ b/src/test/java/zip/ootd/ootdzip/brandrequest/service/BrandRequestServiceTest.java
@@ -185,6 +185,16 @@ class BrandRequestServiceTest {
                 .contains(400, "BR005", "이미 존재하는 영문 브랜드명입니다.");
     }
 
+    @DisplayName("브랜드 요청을 거절한다.")
+    @Test
+    void rejectBrandRequest() {
+        // given
+
+        // when
+
+        //then
+    }
+
     private User createUserBy(String name) {
         User user = User.getDefault();
         user.setName(name);

--- a/src/test/java/zip/ootd/ootdzip/brandrequest/service/BrandRequestServiceTest.java
+++ b/src/test/java/zip/ootd/ootdzip/brandrequest/service/BrandRequestServiceTest.java
@@ -2,13 +2,17 @@ package zip.ootd.ootdzip.brandrequest.service;
 
 import static org.assertj.core.api.Assertions.*;
 
+import java.util.List;
+
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.transaction.annotation.Transactional;
 
 import zip.ootd.ootdzip.brand.domain.Brand;
 import zip.ootd.ootdzip.brand.repository.BrandRepository;
+import zip.ootd.ootdzip.brandrequest.data.BrandRequestStatus;
 import zip.ootd.ootdzip.brandrequest.domain.BrandRequest;
 import zip.ootd.ootdzip.brandrequest.repository.BrandRequestRepository;
 import zip.ootd.ootdzip.brandrequest.service.request.BrandRequestApproveSvcReq;
@@ -34,6 +38,7 @@ class BrandRequestServiceTest {
     private BrandRepository brandRepository;
 
     @DisplayName("브랜드를 건의한다.")
+    @Transactional
     @Test
     void insertBrandRequest() {
         // given
@@ -44,18 +49,19 @@ class BrandRequestServiceTest {
                 .build();
 
         // when
-        brandRequestService.insertBrandReqeust(brandRequestSvcReq, user);
+        brandRequestService.insertBrandRequest(brandRequestSvcReq, user);
 
         //then
-        BrandRequest brandRequest = brandRequestRepository.findOneByRequestName(
-                brandRequestSvcReq.getRequestContents());
+        BrandRequest brandRequest = brandRequestRepository.findOneByRequestContents(
+                brandRequestSvcReq.getRequestContents()).get();
         assertThat(brandRequest)
-                .extracting("requestName", "requestUser.Id")
+                .extracting("requestContents", "requestUser.Id")
                 .contains(brandRequestSvcReq.getRequestContents(), user.getId());
 
     }
 
     @DisplayName("요청 이름이 없이 브랜드를 건의하면 실패한다.")
+    @Transactional
     @Test
     void insertBrandRequestWithEmptyReqeustName() {
         // given
@@ -66,79 +72,117 @@ class BrandRequestServiceTest {
                 .build();
 
         // when & then
-        assertThatThrownBy(() -> brandRequestService.insertBrandReqeust(brandRequestSvcReq, user))
+        assertThatThrownBy(() -> brandRequestService.insertBrandRequest(brandRequestSvcReq, user))
                 .isInstanceOf(CustomException.class)
                 .extracting("errorCode.status", "errorCode.divisionCode", "errorCode.message")
                 .contains(400, "BR001", "브랜드 요청 내용은 필수입니다.");
 
     }
 
-    @DisplayName("브랜드 요청을 승인하여 브랜드를 추가하고 요청자에게 알림이 간다.")
+    @DisplayName("브랜드 요청을 승인하여 브랜드를 추가한다.")
+    @Transactional
     @Test
     void approveBrandRequest() {
         // given
         User requestUser = createUserBy("요청자1");
         BrandRequest brandRequest = createBrandRequestBy("브랜드1", requestUser);
+        BrandRequest brandRequest2 = createBrandRequestBy("브랜드1 요청", requestUser);
+        BrandRequest brandRequest3 = createBrandRequestBy("브랜드1 추가해주세요.", requestUser);
 
         User user = createUserBy("어드민1", UserRole.ADMIN);
-        BrandRequestApproveSvcReq request = new BrandRequestApproveSvcReq();
+        BrandRequestApproveSvcReq request = BrandRequestApproveSvcReq.builder()
+                .brandName("브랜드1")
+                .brandEngName("Brand1")
+                .brandRequestId(List.of(brandRequest.getId(), brandRequest2.getId(), brandRequest3.getId()))
+                .build();
 
         // when
         brandRequestService.approveBrandRequest(request, user);
 
         //then
-        brandRepository.findOneByName("브랜드1");
+        Brand addedBrand = brandRepository.findOneByName("브랜드1").get();
+        List<BrandRequest> result = brandRequestRepository.findAllById(
+                List.of(brandRequest.getId(), brandRequest2.getId(), brandRequest3.getId()));
+
+        assertThat(addedBrand)
+                .extracting("name", "engName")
+                .containsExactlyInAnyOrder(request.getBrandName(), request.getBrandEngName());
+
+        assertThat(result)
+                .extracting("id", "requestStatus")
+                .containsExactlyInAnyOrder(
+                        tuple(brandRequest.getId(), BrandRequestStatus.APPROVED),
+                        tuple(brandRequest2.getId(), BrandRequestStatus.APPROVED),
+                        tuple(brandRequest3.getId(), BrandRequestStatus.APPROVED)
+                );
 
     }
 
-    @DisplayName("브랜드 요청을 승인할 때 브랜드 요청 ID들을 입력하지 않으면 에러가 발생한다.")
+    @DisplayName("브랜드 요청을 승인할 때 일반 유저가 승인하면 에러가 발생한다.")
+    @Transactional
     @Test
-    void approveBrandRequestWithEmptyBrandRequestIds() {
+    void approveBrandRequestWithNoAdminUser() {
         // given
+        User requestUser = createUserBy("요청자1");
+        BrandRequest brandRequest = createBrandRequestBy("브랜드1", requestUser);
 
-        // when
-
-        //then
-    }
-
-    @DisplayName("브랜드 요청을 승인할 때 브랜드명을 입력하지 않으면 에러가 발생한다.")
-    @Test
-    void approveBrandRequestWithoutBrandName() {
-        // given
-
-        // when
-
-        //then
-    }
-
-    @DisplayName("브랜드 요청을 승인할 때 영문 브랜드명을 입력하지 않으면 에러가 발생한다.")
-    @Test
-    void approveBrandRequestWithoutBrandEngName() {
-        // given
-
-        // when
-
-        //then
+        User user = createUserBy("어드민1", UserRole.USER);
+        BrandRequestApproveSvcReq request = BrandRequestApproveSvcReq.builder()
+                .brandName("브랜드1")
+                .brandEngName("Brand1")
+                .brandRequestId(List.of(brandRequest.getId()))
+                .build();
+        // when & then
+        assertThatThrownBy(() -> brandRequestService.approveBrandRequest(request, user))
+                .isInstanceOf(CustomException.class)
+                .extracting("errorCode.status", "errorCode.divisionCode", "errorCode.message")
+                .contains(403, "G008", "Forbidden Exception");
     }
 
     @DisplayName("브랜드 요청을 승인할 때 이미 존재하는 브랜드명을 입력하면 에러가 발생한다.")
+    @Transactional
     @Test
     void approveBrandRequestWithExistBrandName() {
         // given
+        User requestUser = createUserBy("요청자1");
+        BrandRequest brandRequest = createBrandRequestBy("브랜드1", requestUser);
+        Brand brand = createBrandBy("브랜드1", "Brand1");
 
-        // when
+        User user = createUserBy("어드민1", UserRole.ADMIN);
+        BrandRequestApproveSvcReq request = BrandRequestApproveSvcReq.builder()
+                .brandName("브랜드1")
+                .brandEngName("Brand")
+                .brandRequestId(List.of(brandRequest.getId()))
+                .build();
 
-        //then
+        // when & then
+        assertThatThrownBy(() -> brandRequestService.approveBrandRequest(request, user))
+                .isInstanceOf(CustomException.class)
+                .extracting("errorCode.status", "errorCode.divisionCode", "errorCode.message")
+                .contains(400, "BR004", "이미 존재하는 브랜드명입니다.");
     }
 
     @DisplayName("브랜드 요청을 승인할 때 이미 존재하는 영문 브랜드명을 입력하면 에러가 발생한다.")
+    @Transactional
     @Test
     void approveBrandRequestWithExistBrandEngName() {
         // given
+        User requestUser = createUserBy("요청자1");
+        BrandRequest brandRequest = createBrandRequestBy("브랜드1", requestUser);
+        Brand brand = createBrandBy("브랜드1", "Brand1");
 
-        // when
+        User user = createUserBy("어드민1", UserRole.ADMIN);
+        BrandRequestApproveSvcReq request = BrandRequestApproveSvcReq.builder()
+                .brandName("브랜드")
+                .brandEngName("Brand1")
+                .brandRequestId(List.of(brandRequest.getId()))
+                .build();
 
-        //then
+        // when & then
+        assertThatThrownBy(() -> brandRequestService.approveBrandRequest(request, user))
+                .isInstanceOf(CustomException.class)
+                .extracting("errorCode.status", "errorCode.divisionCode", "errorCode.message")
+                .contains(400, "BR005", "이미 존재하는 영문 브랜드명입니다.");
     }
 
     private User createUserBy(String name) {


### PR DESCRIPTION
## 변경사항
- 브랜드 요청 승인 기능
    - 브랜드 요청 승인 시 고유 ID를 리스트 형태로 받아 여러건을 한번에 승인 가능
    - 브랜드 요청 승인 시 브랜드 국문명, 영문명을 받아 브랜드 자동 추가
    - 브랜드를 요청한 유저에게 알림 발송
- 브랜드 요청 거절 기능
    - 브랜드 요청 거절 시 고유 ID를 리스트 형태로 받아 여러건을 한번에 거절 가능
    - 브랜드를 요청한 유저에게 사유 알림 발송
- 브랜드 요청 조회 기능
    - 브랜드 요청 상태, 내용, 요청자로 검색 가능
    - 정렬 컬럼을 여러개 받을 수 있도록 함
    
## 참고사항
- 해당 기능은 관리자만 사용할 수 있도록 하기 위해서 User에 권한을 추가해서 Admin 권한만 사용가능하게 함
- 관리자는 ID/PW로 로그인 가능하게 하고 Admin 엔티티를 따로 만들어서 User쪽과 연결해서 사용하려고 합니다. (다른 의견 있으면 말씀 부탁드립니다!)
    - Admin 엔티티에 ID, PW, User를 만들고 해당 User에 Role을 어드민으로 하여 관리할려고 합니다. 
  
close #226 