### PR TITLE
config : 스웨거 CORS 에러 관련 설정추가

### DIFF
--- a/src/main/java/zip/ootd/ootdzip/OotdzipApplication.java
+++ b/src/main/java/zip/ootd/ootdzip/OotdzipApplication.java
@@ -4,14 +4,6 @@ import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.cache.annotation.EnableCaching;
 
-import io.swagger.v3.oas.annotations.OpenAPIDefinition;
-import io.swagger.v3.oas.annotations.servers.Server;
-
-@OpenAPIDefinition(
-        servers = {
-                @Server(url = "/", description = "Default Server Url")
-        }
-)
 @EnableCaching
 @SpringBootApplication
 public class OotdzipApplication {

--- a/src/main/java/zip/ootd/ootdzip/OotdzipApplication.java
+++ b/src/main/java/zip/ootd/ootdzip/OotdzipApplication.java
@@ -4,6 +4,14 @@ import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.cache.annotation.EnableCaching;
 
+import io.swagger.v3.oas.annotations.OpenAPIDefinition;
+import io.swagger.v3.oas.annotations.servers.Server;
+
+@OpenAPIDefinition(
+        servers = {
+                @Server(url = "/", description = "Default Server Url")
+        }
+)
 @EnableCaching
 @SpringBootApplication
 public class OotdzipApplication {

--- a/src/main/java/zip/ootd/ootdzip/common/config/SwaggerConfig.java
+++ b/src/main/java/zip/ootd/ootdzip/common/config/SwaggerConfig.java
@@ -7,6 +7,7 @@ import org.springframework.context.annotation.Configuration;
 
 import io.swagger.v3.oas.annotations.OpenAPIDefinition;
 import io.swagger.v3.oas.annotations.info.Info;
+import io.swagger.v3.oas.annotations.servers.Server;
 import io.swagger.v3.oas.models.Components;
 import io.swagger.v3.oas.models.OpenAPI;
 import io.swagger.v3.oas.models.security.SecurityRequirement;
@@ -15,7 +16,10 @@ import io.swagger.v3.oas.models.security.SecurityScheme;
 @OpenAPIDefinition(
         info = @Info(title = "OOTD API 명세서",
                 description = "OOTD API 명세서",
-                version = "v1"))
+                version = "v1"),
+        servers = {
+                @Server(url = "/", description = "Default Server Url")
+        })
 @Configuration
 public class SwaggerConfig {
 


### PR DESCRIPTION
- https로 서버를 배포했을 때, 스웨거 사용 시 CORS 가 발생하는 원인이 http -> https로 요청하는것이라고 하여 수정했습니다.
<img width="1680" alt="image" src="https://github.com/user-attachments/assets/08033012-390d-4d5e-8c3d-542eb53e849d">

<img width="1680" alt="image" src="https://github.com/user-attachments/assets/2fc6b878-7be8-4433-8f70-477ee6336378">
- 참고 자료 : https://github.com/springdoc/springdoc-openapi/issues/726
